### PR TITLE
[8.0.0] KOGITO-4919: [DMN Designer] SDM is broken on -kogito-webapp-runtime

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
@@ -470,6 +470,17 @@
     <!-- Client side FEEL -->
     <dependency>
       <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-feel-gwt-functions</artifactId>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.antlr</groupId>
+          <artifactId>antlr4-runtime</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
       <artifactId>kie-dmn-feel-gwt</artifactId>
       <scope>provided</scope>
       <exclusions>


### PR DESCRIPTION
**JIRA**: [KOGITO-4919](https://issues.redhat.com/browse/KOGITO-4919): [DMN Designer] SDM is broken on -kogito-webapp-runtime

--

This PR is not a cherry-pick from the original PR on `kie-wb-common`, but it fixes the `gwt:run` for `-kogito-webapp-runtime`.

--

Here's the [plugin](https://www.dropbox.com/s/1elod69swkyogbl/KOGITO-4919.vsix?dl=0) (just to ensure this PR doesn't introduce regressions on `-kogito-webapp-runtime`) 👀 