### PR TITLE
KOGITO-5082: Restore the notification mechanism

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/notifications/NotificationPopupView.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/notifications/NotificationPopupView.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.views.pfly.notifications;
+
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.ui.DecoratedPopupPanel;
+import org.gwtbootstrap3.client.ui.Alert;
+import org.gwtbootstrap3.client.ui.constants.AlertType;
+import org.uberfire.client.resources.WorkbenchResources;
+import org.uberfire.client.views.pfly.notifications.animations.LinearFadeInAnimation;
+import org.uberfire.client.views.pfly.notifications.animations.Pause;
+import org.uberfire.client.views.pfly.notifications.animations.Sequencer;
+import org.uberfire.workbench.events.NotificationEvent;
+
+/**
+ * The view for an individual newly created notification message.
+ */
+public class NotificationPopupView extends DecoratedPopupPanel {
+
+    private final Alert notification = new Alert();
+
+    public NotificationPopupView() {
+        setStyleName(WorkbenchResources.INSTANCE.CSS().notification());
+        setWidget(notification);
+        notification.setDismissable(true);
+    }
+
+    /**
+     * Set the text to display
+     *
+     * @param text
+     */
+    public void setNotification(final String text) {
+        notification.setText(text);
+    }
+
+    public void setType(final NotificationEvent.NotificationType type) {
+        AlertType bs3Type;
+        switch (type) {
+            case ERROR:
+                bs3Type = AlertType.DANGER;
+                break;
+            case DEFAULT:
+                bs3Type = AlertType.INFO;
+                break;
+            default:
+                bs3Type = AlertType.valueOf(type.toString());
+                break;
+        }
+        notification.setType(bs3Type);
+    }
+
+    /**
+     * Set the width of the Notification pop-up
+     *
+     * @param width
+     */
+    public void setNotificationWidth(final String width) {
+        //Setting the width of the DecoratedPopupPanel causes it to be rendered incorrectly.
+        //We therefore set the size of an internal element that holds the actual content.
+        notification.setWidth(width);
+    }
+
+    public void show(final Command onCompleteCommand) {
+        show(onCompleteCommand,
+             true);
+    }
+
+    /**
+     * Show the Notification pop-up. This consists of fading the pop-up into
+     * view and pausing. Once complete the onCompleteCommand will be executed.
+     *
+     * @param onCompleteCommand
+     */
+    public void show(final Command onCompleteCommand,
+                     final boolean autoHide) {
+
+        final LinearFadeInAnimation fadeInAnimation = new LinearFadeInAnimation(this) {
+            @Override
+            public void onStart() {
+                super.onStart();
+                NotificationPopupView.this.show();
+            }
+        };
+
+        final Pause pauseAnimation = new Pause() {
+            @Override
+            public void onComplete() {
+                super.onComplete();
+                onCompleteCommand.execute();
+            }
+        };
+
+        final Sequencer s = new Sequencer();
+        s.add(fadeInAnimation, 250);
+
+        if (autoHide) {
+            s.add(pauseAnimation, 2000);
+        } else {
+            notification.addCloseHandler(evt -> onCompleteCommand.execute());
+        }
+
+        s.run();
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/notifications/NotificationPopupsManagerView.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/notifications/NotificationPopupsManagerView.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.views.pfly.notifications;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.enterprise.context.Dependent;
+
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
+import org.kie.soup.commons.validation.PortablePreconditions;
+import org.uberfire.client.views.pfly.notifications.animations.LinearFadeOutAnimation;
+import org.uberfire.client.workbench.widgets.notification.NotificationManager;
+import org.uberfire.workbench.events.NotificationEvent;
+
+@Dependent
+public class NotificationPopupsManagerView implements NotificationManager.View {
+
+    private final int SPACING = 48;
+    private final List<PopupHandle> activeNotifications = new ArrayList<PopupHandle>();
+    private final List<PopupHandle> pendingRemovals = new ArrayList<PopupHandle>();
+    //When true we are in the process of removing a notification message
+    private boolean removing = false;
+    private int initialSpacing = SPACING;
+    private IsWidget container;
+
+    @Override
+    public void setContainer(final IsWidget container) {
+        this.container = PortablePreconditions.checkNotNull("container",
+                                                            container);
+    }
+
+    @Override
+    public void setInitialSpacing(int spacing) {
+        this.initialSpacing = spacing;
+    }
+
+    @Override
+    public NotificationManager.NotificationPopupHandle show(NotificationEvent event,
+                                                            Command hideCommand) {
+        if (container == null) {
+            throw new IllegalStateException("The setContainer() method hasn't been called!");
+        }
+
+        final NotificationPopupView view = new NotificationPopupView();
+        final PopupHandle popupHandle = new PopupHandle(view,
+                                                        event);
+
+        activeNotifications.add(popupHandle);
+        int size = activeNotifications.size();
+        int topMargin = (size == 1) ? initialSpacing : (size * SPACING) - (SPACING - initialSpacing);
+        view.setPopupPosition(getLeftPosition(container.asWidget()) + getMargin(),
+                              getTopPosition(container.asWidget()) + topMargin);
+        view.setNotification(event.getNotification());
+        view.setType(event.getType());
+        view.setNotificationWidth(getWidth() + "px");
+
+        view.show(hideCommand,
+                  event.autoHide());
+
+        return popupHandle;
+    }
+
+    private int getTopPosition(final Widget widget) {
+        int top = widget.getAbsoluteTop();
+        // if top is negative (due to scrolling) we try to align with the parent
+        // to make sure the notifications are always visible
+        if (top < 0 && widget.getParent() != null) {
+            top = getTopPosition(widget.getParent());
+        }
+        return Math.max(top,
+                        0);
+    }
+
+    private int getLeftPosition(final Widget widget) {
+        int left = widget.getAbsoluteLeft();
+        // if left is negative (due to scrolling) we try to align with the parent
+        // to make sure the notifications are always visible
+        if (left < 0 && widget.getParent() != null) {
+            left = getLeftPosition(widget.getParent());
+        }
+        return Math.max(left,
+                        0);
+    }
+
+    @Override
+    public void hide(final NotificationManager.NotificationPopupHandle handle) {
+        if (container == null) {
+            throw new IllegalStateException("The setContainer() method hasn't been called!");
+        }
+
+        final int removingIndex = activeNotifications.indexOf(handle);
+        if (removingIndex == -1) {
+            return;
+        }
+        if (removing) {
+            pendingRemovals.add((PopupHandle) handle);
+            return;
+        }
+        removing = true;
+        final NotificationPopupView view = ((PopupHandle) handle).view;
+        final LinearFadeOutAnimation fadeOutAnimation = new LinearFadeOutAnimation(view) {
+            @Override
+            public void onUpdate(double progress) {
+                super.onUpdate(progress);
+                for (int i = removingIndex; i < activeNotifications.size(); i++) {
+                    NotificationPopupView v = activeNotifications.get(i).view;
+                    final int left = v.getPopupLeft();
+                    final int top = (int) (((i + 1) * SPACING) - (progress * SPACING))
+                            - (SPACING - initialSpacing) + getTopPosition(container.asWidget());
+                    v.setPopupPosition(left,
+                                       top);
+                }
+            }
+
+            @Override
+            public void onComplete() {
+                super.onComplete();
+                view.hide();
+                activeNotifications.remove(handle);
+                removing = false;
+                if (pendingRemovals.size() > 0) {
+                    PopupHandle popupHandle = pendingRemovals.remove(0);
+                    hide(popupHandle);
+                }
+            }
+        };
+        fadeOutAnimation.run(500);
+    }
+
+    @Override
+    public void hideAll() {
+        for (NotificationManager.NotificationPopupHandle handle : activeNotifications) {
+            hide(handle);
+        }
+    }
+
+    @Override
+    public boolean isShowing(NotificationEvent event) {
+        for (PopupHandle handle : activeNotifications) {
+            if (handle.event.equals(event)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    //80% of container width
+    private int getWidth() {
+        return (int) (container.asWidget().getElement().getClientWidth() * 0.8);
+    }
+
+    //10% of container width
+    private int getMargin() {
+        return (container.asWidget().getElement().getClientWidth() - getWidth()) / 2;
+    }
+
+    private static class PopupHandle implements NotificationManager.NotificationPopupHandle {
+
+        final NotificationPopupView view;
+        final NotificationEvent event;
+
+        PopupHandle(NotificationPopupView view,
+                    NotificationEvent event) {
+            this.view = PortablePreconditions.checkNotNull("view",
+                                                           view);
+            this.event = PortablePreconditions.checkNotNull("event",
+                                                            event);
+        }
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/notifications/animations/LinearFadeInAnimation.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/notifications/animations/LinearFadeInAnimation.java
@@ -13,18 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.uberfire.client.resources;
+package org.uberfire.client.views.pfly.notifications.animations;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.user.client.ui.Widget;
 
 /**
- * All GWT managed resources for Workbench
+ * A linear animation to fade a Widget from 0.0 to 1.0 opacity
  */
-public interface WorkbenchResources extends ClientBundle {
+public class LinearFadeInAnimation extends SequencedAnimation {
 
-    WorkbenchResources INSTANCE = GWT.create(WorkbenchResources.class);
+    private final Widget widget;
 
-    @Source("css/workbench.css")
-    WorkbenchCss CSS();
+    public LinearFadeInAnimation(final Widget widget) {
+        this.widget = widget;
+    }
+
+    @Override
+    public void onUpdate(double progress) {
+        this.widget.getElement().getStyle().setOpacity(progress);
+    }
+
+    @Override
+    public double interpolate(double progress) {
+        return progress;
+    }
 }

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/notifications/animations/LinearFadeOutAnimation.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/notifications/animations/LinearFadeOutAnimation.java
@@ -13,18 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.uberfire.client.resources;
+package org.uberfire.client.views.pfly.notifications.animations;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.user.client.ui.Widget;
 
 /**
- * All GWT managed resources for Workbench
+ * A linear animation to fade a Widget from 1.0 to 0.0 opacity
  */
-public interface WorkbenchResources extends ClientBundle {
+public class LinearFadeOutAnimation extends SequencedAnimation {
 
-    WorkbenchResources INSTANCE = GWT.create(WorkbenchResources.class);
+    private final Widget widget;
 
-    @Source("css/workbench.css")
-    WorkbenchCss CSS();
+    public LinearFadeOutAnimation(final Widget widget) {
+        this.widget = widget;
+    }
+
+    @Override
+    public void onUpdate(double progress) {
+        this.widget.getElement().getStyle().setOpacity(1.0 - progress);
+    }
+
+    @Override
+    public double interpolate(double progress) {
+        return progress;
+    }
 }

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/notifications/animations/Pause.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/notifications/animations/Pause.java
@@ -13,18 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.uberfire.client.resources;
-
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.resources.client.ClientBundle;
+package org.uberfire.client.views.pfly.notifications.animations;
 
 /**
- * All GWT managed resources for Workbench
+ * A pause (in between animations). Does nothing.
  */
-public interface WorkbenchResources extends ClientBundle {
+public class Pause extends SequencedAnimation {
 
-    WorkbenchResources INSTANCE = GWT.create(WorkbenchResources.class);
-
-    @Source("css/workbench.css")
-    WorkbenchCss CSS();
+    @Override
+    public void onUpdate(double progress) {
+        //Do nothing. This animation simply acts as a delay
+    }
 }

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/notifications/animations/SequencedAnimation.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/notifications/animations/SequencedAnimation.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.client.views.pfly.notifications.animations;
+
+import com.google.gwt.animation.client.Animation;
+
+/**
+ * An animation that can be sequenced to run in a list of animations. In reality
+ * we only GWT's Animation's protected methods to be public so we can chain the
+ * completion of one Animation to another.
+ */
+public abstract class SequencedAnimation extends Animation {
+
+    @Override
+    public double interpolate(double progress) {
+        return super.interpolate(progress);
+    }
+
+    @Override
+    public void onCancel() {
+        super.onCancel();
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+    }
+
+    @Override
+    public void onComplete() {
+        super.onComplete();
+    }
+
+    @Override
+    public abstract void onUpdate(double progress);
+}

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/notifications/animations/Sequencer.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/notifications/animations/Sequencer.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.client.views.pfly.notifications.animations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gwt.animation.client.Animation;
+
+/**
+ * Run a list of animations in order.
+ */
+public class Sequencer {
+
+    private int currentAnimationIndex = 0;
+    //The list of animations
+    private List<AnimationConfiguration> animations = new ArrayList<AnimationConfiguration>();
+
+    /**
+     * Add an animation to the list of animations to be sequenced.
+     *
+     * @param animation
+     * @param duration
+     */
+    public void add(final SequencedAnimation animation,
+                    final int duration) {
+        animations.add(new AnimationConfiguration(new WrappedAnimation(animation),
+                                                  duration));
+    }
+
+    /**
+     * Run all animations.
+     */
+    public void run() {
+        runNextAnimation();
+    }
+
+    /**
+     * Reset the sequence to the begining.
+     */
+    public void reset() {
+        currentAnimationIndex = 0;
+    }
+
+    private void runNextAnimation() {
+        if (currentAnimationIndex < animations.size()) {
+            final AnimationConfiguration config = animations.get(currentAnimationIndex++);
+            final WrappedAnimation animation = config.animation;
+            final int duration = config.duration;
+            animation.run(duration);
+        } else {
+            reset();
+        }
+    }
+
+    //Simple holder for sequenced animation details
+    private class AnimationConfiguration {
+
+        final WrappedAnimation animation;
+
+        final int duration;
+
+        AnimationConfiguration(final WrappedAnimation animation,
+                               final int duration) {
+            this.animation = animation;
+            this.duration = duration;
+        }
+    }
+
+    //A wrapper for sequenced animations allowing us to hook into the onComplete method to launch the next animation
+    private class WrappedAnimation extends Animation {
+
+        private final SequencedAnimation animation;
+
+        WrappedAnimation(final SequencedAnimation animation) {
+            this.animation = animation;
+        }
+
+        @Override
+        public void onComplete() {
+            //Pass through to the wrapped animation
+            animation.onComplete();
+            runNextAnimation();
+        }
+
+        @Override
+        protected void onUpdate(double progress) {
+            //Pass through to the wrapped animation
+            animation.onUpdate(progress);
+        }
+
+        @Override
+        public void cancel() {
+            //Pass through to the wrapped animation
+            animation.cancel();
+        }
+
+        @Override
+        protected double interpolate(double progress) {
+            //Pass through to the wrapped animation
+            return animation.interpolate(progress);
+        }
+
+        @Override
+        protected void onCancel() {
+            //Pass through to the wrapped animation
+            animation.onCancel();
+        }
+
+        @Override
+        protected void onStart() {
+            //Pass through to the wrapped animation
+            animation.onStart();
+        }
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/resources/WorkbenchCss.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/resources/WorkbenchCss.java
@@ -15,16 +15,12 @@
  */
 package org.uberfire.client.resources;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.resources.client.CssResource;
 
 /**
- * All GWT managed resources for Workbench
+ * GWT managed CSS for Workbench
  */
-public interface WorkbenchResources extends ClientBundle {
+public interface WorkbenchCss extends CssResource {
 
-    WorkbenchResources INSTANCE = GWT.create(WorkbenchResources.class);
-
-    @Source("css/workbench.css")
-    WorkbenchCss CSS();
+    String notification();
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/notification/NotificationManager.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/notification/NotificationManager.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.workbench.widgets.notification;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.RootPanel;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.kie.soup.commons.validation.PortablePreconditions;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.mvp.impl.DefaultPlaceRequest;
+import org.uberfire.workbench.events.NotificationEvent;
+
+/**
+ * Observes all notification events, and coordinates their display and removal.
+ */
+@ApplicationScoped
+public class NotificationManager {
+
+    private final Map<PlaceRequest, View> notificationsContainerViewMap = new HashMap<>();
+    private final PlaceRequest rootPlaceRequest = new DefaultPlaceRequest("org.uberfire.client.workbench.widgets.notifications.root");
+    private SyncBeanManager iocManager;
+
+    public NotificationManager() {
+    }
+
+    @Inject
+    public NotificationManager(final SyncBeanManager iocManager) {
+        this.iocManager = iocManager;
+    }
+
+    /**
+     * Adds a new notification message to the system, asking the notification presenter to display it, and storing it in
+     * the list of existing notifications. This method can be invoked directly, or it can be invoked indirectly by
+     * firing a CDI {@link NotificationEvent}.
+     *
+     * @param event The notification to display and store in the notification system.
+     */
+    public void addNotification(@Observes final NotificationEvent event) {
+        //If an explicit container has not been specified use the RootPanel
+        IsWidget notificationsContainer = RootPanel.get();
+
+        //Lookup, or create, a View specific to the container
+        View notificationsContainerView = notificationsContainerViewMap.get(rootPlaceRequest);
+        if (notificationsContainerView == null) {
+            final SyncBeanDef<View> containerViewBeanDef = iocManager.lookupBean(View.class);
+            if (containerViewBeanDef != null) {
+                notificationsContainerView = containerViewBeanDef.getInstance();
+                notificationsContainerView.setContainer(notificationsContainer);
+
+                if (event.getInitialTopOffset() != null) {
+                    notificationsContainerView.setInitialSpacing(event.getInitialTopOffset());
+                } else {
+                    notificationsContainerView.setInitialSpacing(0);
+                }
+
+                notificationsContainerViewMap.put(rootPlaceRequest,
+                                                  notificationsContainerView);
+            }
+        }
+        if (notificationsContainerView == null) {
+            return;
+        }
+
+        //Show notification in the container
+        if (!event.isSingleton() || !notificationsContainerView.isShowing(event)) {
+            HideNotificationCommand hideCommand = new HideNotificationCommand(notificationsContainerView);
+            NotificationPopupHandle handle = notificationsContainerView.show(event,
+                                                                             hideCommand);
+            hideCommand.setHandle(handle);
+        }
+    }
+
+    public interface NotificationPopupHandle {
+
+    }
+
+    /**
+     * The view contract for the UI that shows and hides active notifications.
+     */
+    public interface View {
+
+        /**
+         * either {@link #show(NotificationEvent, Command)} or {@link #hide(NotificationPopupHandle)}
+         * and must be passed a non-null value.
+         *
+         * @param container The container relative to which Notifications will be shown. Must not be null.
+         */
+        void setContainer(final IsWidget container);
+
+        /**
+         * Configures the initial vertical spacing for the first notifications
+         * (see {@link NotificationEvent#getInitialTopOffset()}). A default value is
+         * used if this method is never invoked.
+         *
+         * @param spacing the vertical spacing in number of pixels
+         */
+        void setInitialSpacing(int spacing);
+
+        /**
+         * Displays a notification with the given severity and contents.
+         *
+         * @param event       The notification event. Must not be null.
+         * @param hideCommand The command that must be called when the notification is to be closed. When this command is
+         *                    invoked, the notification manager will change the notification status from active to acknowledged,
+         *                    and it will invoke the {@link #hide(NotificationPopupHandle)} method with the notification handle
+         *                    that this method call returned.
+         * @return The object to pass to {@link #hide(NotificationPopupHandle)} that will hide this notification. Must
+         * not return null.
+         */
+        NotificationPopupHandle show(final NotificationEvent event,
+                                     final Command hideCommand);
+
+        /**
+         * Hides the active notification identified by the given popup handle. This call is made when a notification
+         * changes state from "new" to "acknowledged." Once this call is made, the notification is still in the system,
+         * but it should not be displayed as a new notification anymore. As an analogy, if the notification was an
+         * email, this call would mark it as read.
+         *
+         * @param popup The handle for the active notification that should be hidden.
+         */
+        void hide(final NotificationPopupHandle popup);
+
+        /**
+         * Hides all active notifications.
+         */
+        void hideAll();
+
+        /**
+         * Checks whether the given event is currently being shown.
+         *
+         * @param event The notification event. Must not be null.
+         * @return true if shown
+         */
+        boolean isShowing(final NotificationEvent event);
+    }
+
+    private class HideNotificationCommand implements Command {
+
+        private final View notificationContainerView;
+        private NotificationPopupHandle handle;
+
+        HideNotificationCommand(final View notificationContainerView) {
+            this.notificationContainerView = PortablePreconditions.checkNotNull("notificationContainerView",
+                                                                                notificationContainerView);
+        }
+
+        @Override
+        public void execute() {
+            if (handle == null) {
+                throw new IllegalStateException("The show() method hasn't returned a handle yet!");
+            }
+            notificationContainerView.hide(handle);
+        }
+
+        void setHandle(NotificationPopupHandle handle) {
+            this.handle = handle;
+        }
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/main/resources/org/uberfire/client/resources/css/workbench.css
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/resources/org/uberfire/client/resources/css/workbench.css
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+.notification {
+    border: 0;
+    margin: 0;
+    padding: 0;
+    z-index: 100000;
+}
+
 .uf-scroll-panel {
     height: 100%;
     width: 100%;


### PR DESCRIPTION
In this PR, the notification mechanism from [appformer](https://github.com/kiegroup/appformer/) is restored.

All necessary classes were copied as-is from appformer, 
though some minor changes had to be made in order to make the code compatible with this repository. 

Please keep in mind that this notification mechanism will probably be replaced in favor of each channel's approach.
For now, let's use this code so things are kept the way it was.

Example: Error notification is shown when loading an invalid dmn file in a scesim file
![Screenshot from 2021-05-06 16-28-54](https://user-images.githubusercontent.com/638737/117354875-4157f200-ae88-11eb-8925-d4c28ff90de4.png)

**Note**: This code only adds the infrastructure for showing the notification popup. No notification message has been changed.