### PR TITLE
KOGITO-4977: Stunner - Texts overlap toolboxes

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/toolbox/actions/FlowActionsToolboxView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/toolbox/actions/FlowActionsToolboxView.java
@@ -25,11 +25,9 @@ import com.ait.lienzo.client.core.event.AbstractNodeMouseEvent;
 import com.ait.lienzo.client.core.shape.toolbox.ToolboxVisibilityExecutors;
 import com.ait.lienzo.client.core.shape.toolbox.grid.AutoGrid;
 import com.ait.lienzo.client.core.shape.toolbox.items.ButtonItem;
-import com.ait.lienzo.client.core.shape.toolbox.items.decorator.BoxDecorator;
 import com.ait.lienzo.client.core.shape.toolbox.items.impl.ItemsToolboxHighlight;
 import com.ait.lienzo.client.core.shape.toolbox.items.impl.ToolboxFactory;
 import com.ait.lienzo.client.core.shape.toolbox.items.tooltip.ToolboxTextTooltip;
-import com.ait.lienzo.client.core.types.Shadow;
 import com.ait.lienzo.shared.core.types.ColorName;
 import com.ait.lienzo.shared.core.types.Direction;
 import org.kie.workbench.common.stunner.client.lienzo.components.glyph.LienzoGlyphRenderers;
@@ -74,6 +72,16 @@ public class FlowActionsToolboxView
                               .withIconSize(getGlyphSize())
                               .towards(GRID_TOWARDS)
                               .build())
+                .decorate(getToolboxFactory()
+                                  .decorators()
+                                  .box()
+                                  .setPadding(BUTTON_PADDING)
+                                  .configure(path -> {
+                                      path.setFillAlpha(0.95);
+                                      path.setFillColor(ColorName.WHITE);
+                                      path.setStrokeAlpha(0);
+                                  })
+                )
                 .useShowExecutor(ToolboxVisibilityExecutors.upScaleX())
                 .useHideExecutor(ToolboxVisibilityExecutors.downScaleX());
         highlight = new ItemsToolboxHighlight(getToolboxView());
@@ -85,17 +93,6 @@ public class FlowActionsToolboxView
                 .tooltips()
                 .forToolbox(getToolboxView())
                 .withText(defaultTextConsumer());
-    }
-
-    @Override
-    protected BoxDecorator createDecorator() {
-        final BoxDecorator decorator = super.createDecorator();
-        decorator.configure(path -> {
-            path.setStrokeWidth(1)
-                    .setStrokeColor("#0000FF")
-                    .setShadow(new Shadow(ColorName.BLACK.getColor().setA(0.80), 10, 3, 3));
-        });
-        return decorator;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/toolbox/actions/MorphActionsToolboxView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/toolbox/actions/MorphActionsToolboxView.java
@@ -114,13 +114,16 @@ public class MorphActionsToolboxView
                         .decorate(getToolboxFactory()
                                           .decorators()
                                           .button()
-                                          .setPadding(BUTTON_PADDING)
-                                          .configure(path -> path.setFillColor(ColorName.LIGHTGREY)))
+                                          .setPadding(BUTTON_PADDING))
                         .decorateGrid(getToolboxFactory()
                                               .decorators()
                                               .button()
                                               .setPadding(GRID_DECORATOR_PADDING)
-                                              .configure(path -> path.setFillColor("#e6e6e6")));
+                                              .configure(path -> {
+                                                  path.setFillColor(ColorName.WHITE);
+                                                  path.setFillAlpha(0.95);
+                                                  path.setStrokeAlpha(0);
+                                              }));
         getToolboxView().add(gridItem);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/components/toolbox/actions/AbstractActionsToolboxViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/components/toolbox/actions/AbstractActionsToolboxViewTest.java
@@ -109,6 +109,7 @@ public abstract class AbstractActionsToolboxViewTest {
         when(tooltipFactory.forToolbox(any())).thenReturn(toolboxTooltip);
         when(boxDecorator.configure(any())).thenReturn(boxDecorator);
         when(boxDecorator.copy()).thenReturn(boxDecorator);
+        when(boxDecorator.setPadding(5)).thenReturn(boxDecorator);
         when(toolboxViewBoundingBox.getWidth()).thenReturn(300d);
         when(toolboxViewBoundingBox.getHeight()).thenReturn(600d);
         when(toolboxView.getBoundingBox()).thenReturn(toolboxViewBoundingBox);


### PR DESCRIPTION
Hi @romartin, @karreiro, 

I updated East and South toolboxes as discussed on the Jira issue:
![image](https://user-images.githubusercontent.com/1477262/118299084-9925d700-b4e0-11eb-9d46-56c310260445.png)
<img width="435" alt="image" src="https://user-images.githubusercontent.com/1477262/118486980-8860a580-b71a-11eb-801c-b0c87838338f.png">


To test it you can use
* VS [Code plugin](https://drive.google.com/file/d/1AIs_vQd-8ewPTd-Md_Cb1CKoiDJ11IQk/view?usp=sharing)
* or [Standalone editor](https://drive.google.com/file/d/1BDMMTpS4yaQvrXqzjQ5A29rVM-GTsIWs/view?usp=sharing)

Thank you!