### PR TITLE
KOGITO-5068: Online DMN Editor won't load after several tabs are opened

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/sys/PatternFlyBootstrapper.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/sys/PatternFlyBootstrapper.java
@@ -89,10 +89,10 @@ public class PatternFlyBootstrapper {
 
     public static void ensureMonacoEditorLoaderIsAvailable() {
         if (!isMonacoEditorLoaded) {
-            isMonacoEditorLoaded = true;
-            ScriptInjector.fromUrl(PatternFlyClientBundle.INSTANCE.monacoEditor().getSafeUri().asString())
+            ScriptInjector.fromString(PatternFlyClientBundle.INSTANCE.monacoEditor().getText())
                     .setWindow(ScriptInjector.TOP_WINDOW)
                     .inject();
+            isMonacoEditorLoaded = true;
         }
     }
 

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/sys/PatternFlyClientBundle.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/sys/PatternFlyClientBundle.java
@@ -37,8 +37,6 @@ public interface PatternFlyClientBundle extends ClientBundle {
     @Source("org/uberfire/client/views/static/moment-timezone/moment-timezone-with-data-2012-2022.min.js")
     TextResource momentTimeZone();
 
-    @DataResource.DoNotEmbed
-    @DataResource.MimeType("text/javascript")
     @Source("org/uberfire/client/views/static/appformer-js-monaco/monaco.min.js")
-    DataResource monacoEditor();
+    TextResource monacoEditor();
 }

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/sys/PatternFlyClientBundle.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/sys/PatternFlyClientBundle.java
@@ -18,7 +18,6 @@ package org.uberfire.client.views.pfly.sys;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.resources.client.ClientBundle;
-import com.google.gwt.resources.client.DataResource;
 import com.google.gwt.resources.client.TextResource;
 
 public interface PatternFlyClientBundle extends ClientBundle {


### PR DESCRIPTION
The errors on the Jira point to Monaco not being loaded properly at the moment we try to register the FEEL language. After several attempts of making Monaco be lazily loaded properly, I found out that the code is too much reliant on it being synchronous, so making it sync again is the easiest and most reliable solution for now. 

This adds the Monaco editors bundle (~2mb) to the GWT bundle again, though.