### PR TITLE
KOGITO-5135: [SceSim Designer] HiDPI is not working as expected

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/ScenarioSimulationEditorEntryPoint.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/ScenarioSimulationEditorEntryPoint.java
@@ -17,6 +17,7 @@ package org.drools.workbench.screens.scenariosimulation.client;
 
 import javax.annotation.PostConstruct;
 
+import com.ait.lienzo.client.core.config.LienzoCore;
 import org.drools.workbench.screens.scenariosimulation.client.resources.ScenarioSimulationEditorResources;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 
@@ -26,5 +27,6 @@ public class ScenarioSimulationEditorEntryPoint {
     @PostConstruct
     public void startApp() {
         ScenarioSimulationEditorResources.INSTANCE.css().ensureInjected();
+        LienzoCore.get().setHidpiEnabled(true);
     }
 }


### PR DESCRIPTION
**JIRA**: [KOGITO-5135](https://issues.redhat.com/browse/KOGITO-5135): [SceSim Designer] HiDPI is not working as expected

**VS Code plugin**: [plugin](https://www.dropbox.com/s/tqm9um6loy3asem/KOGITO-5135.vsix?dl=0)

--

It's the same fix introduced by https://github.com/kiegroup/kogito-editors-java/pull/12, but applied in the SceSim editor.

--

Before:
<img width="2205" alt="Screen Shot 2021-05-17 at 18 27 38" src="https://user-images.githubusercontent.com/1079279/118526632-be188500-b740-11eb-8388-4acd6d74763c.png">


After:
<img width="2205" alt="Screen Shot 2021-05-17 at 18 48 11" src="https://user-images.githubusercontent.com/1079279/118526619-ba84fe00-b740-11eb-8f77-7edd8a64e3d7.png">

