### PR TITLE
Bump version to 8.2.1-SNAPSHOT

### DIFF
--- a/appformer-bom/pom.xml
+++ b/appformer-bom/pom.xml
@@ -18,7 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kie.kogito</groupId>
   <artifactId>appformer-bom</artifactId>
-  <version>8.1.1-SNAPSHOT</version>
+  <version>8.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Appformer BOM</name>

--- a/appformer-client-api/pom.xml
+++ b/appformer-client-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/appformer-js-monaco/pom.xml
+++ b/appformer-js-monaco/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/appformer-kogito-bridge/pom.xml
+++ b/appformer-kogito-bridge/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/drools-wb-bom/pom.xml
+++ b/drools-wb-bom/pom.xml
@@ -18,7 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kie.kogito</groupId>
   <artifactId>drools-wb-bom</artifactId>
-  <version>8.1.1-SNAPSHOT</version>
+  <version>8.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Drools-wb BOM</name>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/pom.xml
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools-wb-scenario-simulation-editor</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-wb-scenario-simulation-editor-api</artifactId>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools-wb-scenario-simulation-editor</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-wb-scenario-simulation-editor-client</artifactId>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/pom.xml
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools-wb-scenario-simulation-editor</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-wb-scenario-simulation-editor-kogito-client</artifactId>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-marshaller/pom.xml
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-marshaller/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools-wb-scenario-simulation-editor</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-wb-scenario-simulation-editor-kogito-marshaller</artifactId>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/pom.xml
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-wb-scenario-simulation-editor</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-testing/pom.xml
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-testing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools-wb-scenario-simulation-editor</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/pom.xml
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools-wb-screens</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-wb-scenario-simulation-editor</artifactId>

--- a/drools-wb-screens/pom.xml
+++ b/drools-wb-screens/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-editors-java</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-api/pom.xml
+++ b/errai-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>errai-api</artifactId>
   <name>Errai::API</name>

--- a/errai-bom/pom.xml
+++ b/errai-bom/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.kie.kogito</groupId>
   <artifactId>errai-bom</artifactId>
-  <version>8.1.1-SNAPSHOT</version>
+  <version>8.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>JBoss Errai BOM</name>
 

--- a/errai-cdi/errai-cdi-client/pom.xml
+++ b/errai-cdi/errai-cdi-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>cdi-integration-parent</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/errai-cdi/errai-cdi-shared/pom.xml
+++ b/errai-cdi/errai-cdi-shared/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>cdi-integration-parent</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-cdi/pom.xml
+++ b/errai-cdi/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-codegen-gwt/pom.xml
+++ b/errai-codegen-gwt/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-codegen/pom.xml
+++ b/errai-codegen/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>Errai::Codegen</name>

--- a/errai-common/pom.xml
+++ b/errai-common/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-config/pom.xml
+++ b/errai-config/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/errai-data-binding/pom.xml
+++ b/errai-data-binding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-ioc/pom.xml
+++ b/errai-ioc/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-javax-enterprise/pom.xml
+++ b/errai-javax-enterprise/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-editors-java</artifactId>
-        <version>8.1.1-SNAPSHOT</version>
+        <version>8.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/errai-reflections/pom.xml
+++ b/errai-reflections/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-reflections/reflections/pom.xml
+++ b/errai-reflections/reflections/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>reflections-parent</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/errai-ui/pom.xml
+++ b/errai-ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/errai-validation/pom.xml
+++ b/errai-validation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-bom/pom.xml
+++ b/kie-wb-common-bom/pom.xml
@@ -18,7 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kie.kogito</groupId>
   <artifactId>kie-wb-common-bom</artifactId>
-  <version>8.1.1-SNAPSHOT</version>
+  <version>8.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Kie-wb-common BOM</name>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kie-wb-common-dmn</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kie-wb-common-dmn</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-common/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kie-wb-common-dmn</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kie-wb-common-dmn</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-marshaller/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-marshaller/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>kie-wb-common-dmn</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kie-wb-common-dmn</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kie-wb-common-dmn</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-dmn/pom.xml
+++ b/kie-wb-common-dmn/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-api/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-dynamic-forms</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-dynamic-forms</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-common-rendering</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-shared/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-shared/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-common-rendering</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-commons</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-crud-component/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-crud-component/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-commons</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-processing-engine/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-processing-engine/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-commons</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-base/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-base/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-adf</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-api/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-adf-engine</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-client/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-adf-engine</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-adf</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-adf</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-core</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-core</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-core</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/pom.xml
+++ b/kie-wb-common-forms/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kogito-editors-java</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-kogito/kie-wb-common-kogito-api/pom.xml
+++ b/kie-wb-common-kogito/kie-wb-common-kogito-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kie-wb-common-kogito</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-kogito/kie-wb-common-kogito-client/pom.xml
+++ b/kie-wb-common-kogito/kie-wb-common-kogito-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kie-wb-common-kogito</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-kogito/kie-wb-common-kogito-webapp-base/pom.xml
+++ b/kie-wb-common-kogito/kie-wb-common-kogito-webapp-base/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-wb-common-kogito</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-kogito/pom.xml
+++ b/kie-wb-common-kogito/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-client</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-shapes</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-shapes</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-client</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-client</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-api</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-api</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-api</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-core</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-commons</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-commons</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-core</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-core</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kie-wb-common-stunner</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-forms</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-forms</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-kogito</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-svg/kie-wb-common-stunner-svg-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-svg/kie-wb-common-stunner-svg-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-svg</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-svg/kie-wb-common-stunner-svg-gen/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-svg/kie-wb-common-stunner-svg-gen/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-svg</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-svg/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-svg/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kie-wb-common-stunner</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kie-wb-common-stunner-bpmn</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kie-wb-common-stunner-bpmn</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-emf/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-emf/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-bpmn</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-bpmn</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-bpmn</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kie-wb-common-stunner-sets</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kie-wb-common-stunner</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/pom.xml
+++ b/kie-wb-common-stunner/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kogito-editors-java</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-widgets/kie-wb-common-ui/pom.xml
+++ b/kie-wb-common-widgets/kie-wb-common-ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kie-wb-common-widgets</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-ui</artifactId>

--- a/kie-wb-common-widgets/pom.xml
+++ b/kie-wb-common-widgets/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-editors-java</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kie.kogito</groupId>
   <artifactId>kogito-editors-java</artifactId>
-  <version>8.1.1-SNAPSHOT</version>
+  <version>8.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Kogito Editors Java - Parent</name>

--- a/uberfire-api/pom.xml
+++ b/uberfire-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-client-api/pom.xml
+++ b/uberfire-client-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/pom.xml
+++ b/uberfire-extensions/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/uberfire-commons-editor/pom.xml
+++ b/uberfire-extensions/uberfire-commons-editor/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-extensions</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/pom.xml
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-commons-editor</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-commons-editor-api</artifactId>

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-commons-editor</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-commons-editor-client</artifactId>

--- a/uberfire-extensions/uberfire-layout-editor/pom.xml
+++ b/uberfire-extensions/uberfire-layout-editor/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-extensions</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-api/pom.xml
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-layout-editor</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-layout-editor-api</artifactId>

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/pom.xml
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-layout-editor</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-layout-editor-client</artifactId>

--- a/uberfire-extensions/uberfire-simple-docks/pom.xml
+++ b/uberfire-extensions/uberfire-simple-docks/pom.xml
@@ -21,7 +21,7 @@
    <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-extensions</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/pom.xml
+++ b/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-simple-docks</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-simple-docks-client</artifactId>

--- a/uberfire-extensions/uberfire-widgets/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-extensions</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-widgets</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-widgets-commons</artifactId>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-widgets</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-widgets-core</artifactId>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-widgets-core</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-widgets-core-client</artifactId>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-table/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-table/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-widgets</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-widgets-table</artifactId>

--- a/uberfire-extensions/uberfire-wires/pom.xml
+++ b/uberfire-extensions/uberfire-wires/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-extensions</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-wires</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-wires-core</artifactId>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-wires-core</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-wires-core-grids</artifactId>

--- a/uberfire-workbench/pom.xml
+++ b/uberfire-workbench/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-editors-java</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-workbench</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-workbench-client-views-patternfly</artifactId>

--- a/uberfire-workbench/uberfire-workbench-client/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-workbench</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-workbench-client</artifactId>

--- a/uberfire-workbench/uberfire-workbench-processors/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-processors/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>uberfire-workbench</artifactId>
-    <version>8.1.1-SNAPSHOT</version>
+    <version>8.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-workbench-processors</artifactId>


### PR DESCRIPTION
Bump version to 8.2.1-SNAPSHOT.

I've bumped it manually due to an error in the release workflow (https://github.com/actions/checkout/issues/417).