### PR TITLE
BXMSPROD-1340 kogito-tooling nightly

### DIFF
--- a/kogito-editors-js/package.json
+++ b/kogito-editors-js/package.json
@@ -14,7 +14,7 @@
     "new-component": "node ./scripts/new-component.js",
     "bootstrap": "yarn run init && lerna bootstrap",
     "build:dev": "rimraf dist && lerna run build:dev --stream",
-    "build:prod": "rimraf dist && yarn format:check && lerna run build:prod --stream",
+    "build:prod": "rimraf dist && yarn format:check && lerna run build:prod --stream && yarn info",
     "gwt:wire": "lerna run build:dev && lerna run build:watch --parallel",
     "format": "prettier --write .",
     "format:check": "prettier --check ."


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1340

I didn't find a better way to avoid `--registry=X` flag error running yarn build:prod
```
[INFO] Running 'yarn build:prod --registry=RH_repo' in /home/jenkins/workspace/PROD_kogito-tooling.nightly_main/kiegroup_kogito-editors-java/kogito-editors-js
[INFO] yarn run v1.22.10
[INFO] $ rimraf dist && yarn format:check && lerna run build:prod --stream --registry=https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/
[INFO] $ prettier --check .
[INFO] Checking formatting...
[INFO] All matched files use Prettier code style!
[INFO] ERR! lerna Unknown argument: registry
[INFO] error Command failed with exit code 1.
[INFO] info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

```
[webpack-cli] Error: Unknown option '--registry=RH_repo'
[webpack-cli] Run 'webpack --help' to see available commands and options
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

it is true additional arguments won't be taken into consideration in case `build:prod` from packages change... any better idea?
