### PR TITLE
KOGITO-5549 - WID files with comments and Imports can't be loaded

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/workitem/WorkItemDefinitionClientParser.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/workitem/WorkItemDefinitionClientParser.java
@@ -285,7 +285,8 @@ public class WorkItemDefinitionClientParser {
 
     private static boolean isComment(char symbol) {
         if (isSlash(symbol)) {
-            if (isSlash(widString.charAt(index + 1))) {
+            if (isSlash(widString.charAt(index + 1))
+                    || isStar(widString.charAt(index + 1))) {
                 return true;
             }
         }
@@ -294,6 +295,26 @@ public class WorkItemDefinitionClientParser {
     }
 
     private static void skipComment() {
+        index++;
+        if (isStar(getCurrentSymbol())) {
+            skipMultiLineComment();
+        } else {
+            skipSingleLineComment();
+        }
+    }
+
+    private static void skipMultiLineComment() {
+        do {
+            index++;
+            if (isStar(getCurrentSymbol())
+                    && isSlash(widString.charAt(index + 1))) {
+                index += 2;
+                break;
+            }
+        } while (true);
+    }
+
+    private static void skipSingleLineComment() {
         do {
             index++;
             if (getCurrentSymbol() == '\n') {
@@ -357,6 +378,10 @@ public class WorkItemDefinitionClientParser {
 
     private static boolean isSlash(char symbol) {
         return symbol == '/';
+    }
+
+    private static boolean isStar(char symbol) {
+        return symbol == '*';
     }
 
     private static boolean isObjectStart(char symbol) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/workitem/WorkItemDefinitionClientParser.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/workitem/WorkItemDefinitionClientParser.java
@@ -75,9 +75,7 @@ public class WorkItemDefinitionClientParser {
     }
 
     private static List<WorkItemDefinition> parseWid() {
-        if (notObjectStart(skipWhitespaceAndComments())) {
-            throw new IllegalArgumentException("Invalid parameter");
-        }
+        skipToObjectStart();
         findNextToken();
 
         List<Map<String, Object>> widFile = new ArrayList<>();
@@ -414,6 +412,14 @@ public class WorkItemDefinitionClientParser {
 
     private static boolean notObjectEnd(char symbol) {
         return !isObjectEnd(symbol);
+    }
+
+    private static void skipToObjectStart() {
+        skipWhitespaceAndComments();
+        while (notObjectStart(getCurrentSymbol())) {
+            index++;
+            skipWhitespaceAndComments();
+        }
     }
 
     private static boolean notObjectStart(char symbol) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/workitem/WorkItemDefinitionClientParserTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/workitem/WorkItemDefinitionClientParserTest.java
@@ -45,6 +45,7 @@ public class WorkItemDefinitionClientParserTest {
     private static final String INVALID_START_WID_FILE = "org/kie/workbench/common/stunner/bpmn/client/workitem/invalidWidStart.wid";
     private static final String SECOND_WID_IS_INCORRECT_WID_FILE = "org/kie/workbench/common/stunner/bpmn/client/workitem/secondWidIsIncorrect.wid";
     private static final String MVEL_LIST_IN_WID_FILE = "org/kie/workbench/common/stunner/bpmn/client/workitem/listParameters.wid";
+    private static final String SINGLE_LINE_COMMENTS_FILE = "org/kie/workbench/common/stunner/bpmn/client/workitem/singleLineComments.wid";
 
     final static String EMAIL_WID_EXTRACTED_PARAMETERS = "|Body:String,From:String,Subject:String,To:String|";
     final static String RESULT_WID_RETURN_EXTRACTED_PARAMETERS = "|Result:java.lang.Object|";
@@ -55,6 +56,8 @@ public class WorkItemDefinitionClientParserTest {
 
     final static String REST_WID_EXTRACTED_PARAMETERS = "|ConnectTimeout:String,ContentData:String,Method:String," +
             "Password:String,ReadTimeout:String,Url:String,Username:String|";
+
+    final static String REST_WID_EXTRACTED_NOT_COMMENTED_PARAMETERS = "|ConnectTimeout:String,Method:String,ReadTimeout:String|";
 
     final static private String ICON_64 = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgAAAAIACAYAAAD0eNT6AAAYK0lEQVR4nO3de9z1+Vzv8dcMcxCjDMMwjHMOUw5D52ypFMmmaJuaKFTa6YBSm+hgt4lIOmt33nJKg8gWiYrHVDpK2zk1coxhNDOYw93+Y/VoYua+5z5c1/VZa/2ez8fj9b+xfuv9Xfd1rev3KwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA23rWrU6qTqxOr42f/5wAAR+rY6ubV3apvrn6o+uXqFdWbqwuqf7uCLqk+VL21em31gurp1fdUX13dojp67/4zAIBPdUx1p+ph1dOq367+rHpvta8rPuB3oo9Vf1E9s/qW6jbVUbv83woAi3WL6huqn6rObnUQ79Yhf6h9oHpuq582XHeX/vsBYOud1OpH7k+oXt7qx/LTh/zBdmn1J9V35cMAABzQcdW9Wv2e/p3NH+I71cXVi//9v813BwCgukb1gFY";
 
@@ -212,6 +215,20 @@ public class WorkItemDefinitionClientParserTest {
         assertEquals("Email", wid1.getName());
         assertEquals("Display Email", wid1.getDisplayName());
         assertEquals("Some documentation", wid1.getDocumentation());
+    }
+
+    @Test
+    public void testSingleLineComments() {
+        String widFile = loadTestFile(SINGLE_LINE_COMMENTS_FILE);
+        List<WorkItemDefinition> defs = WorkItemDefinitionClientParser.parse(widFile);
+        assertEquals(1, defs.size());
+
+        WorkItemDefinition wid3 = defs.get(0);
+        assertEquals("Rest", wid3.getName());
+        assertEquals("REST", wid3.getDisplayName());
+        assertEquals("", wid3.getIconDefinition().getUri());
+        assertEquals(RESULT_WID_RETURN_EXTRACTED_PARAMETERS, wid3.getResults());
+        assertEquals(REST_WID_EXTRACTED_NOT_COMMENTED_PARAMETERS, wid3.getParameters());
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/workitem/WorkItemDefinitionClientParserTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/workitem/WorkItemDefinitionClientParserTest.java
@@ -47,6 +47,7 @@ public class WorkItemDefinitionClientParserTest {
     private static final String MVEL_LIST_IN_WID_FILE = "org/kie/workbench/common/stunner/bpmn/client/workitem/listParameters.wid";
     private static final String SINGLE_LINE_COMMENTS_FILE = "org/kie/workbench/common/stunner/bpmn/client/workitem/singleLineComments.wid";
     private static final String MULTI_LINE_COMMENTS_FILE = "org/kie/workbench/common/stunner/bpmn/client/workitem/multiLineComments.wid";
+    private static final String IMPORT_PART_IGNORED = "org/kie/workbench/common/stunner/bpmn/client/workitem/importPartIgnored.wid";
 
     final static String EMAIL_WID_EXTRACTED_PARAMETERS = "|Body:String,From:String,Subject:String,To:String|";
     final static String RESULT_WID_RETURN_EXTRACTED_PARAMETERS = "|Result:java.lang.Object|";
@@ -244,6 +245,21 @@ public class WorkItemDefinitionClientParserTest {
         assertEquals("", wid3.getIconDefinition().getUri());
         assertEquals(RESULT_WID_RETURN_EXTRACTED_PARAMETERS, wid3.getResults());
         assertEquals(REST_WID_EXTRACTED_NOT_COMMENTED_PARAMETERS, wid3.getParameters());
+    }
+
+    @Test
+    public void testIgnoreImportPart() {
+        String widFile = loadTestFile(IMPORT_PART_IGNORED);
+        List<WorkItemDefinition> defs = WorkItemDefinitionClientParser.parse(widFile);
+
+        assertEquals(1, defs.size());
+        WorkItemDefinition wid1 = defs.get(0);
+
+        assertEquals("Rest", wid1.getName());
+        assertEquals("REST", wid1.getDisplayName());
+        assertEquals("defaultservicenodeicon.png", wid1.getIconDefinition().getUri());
+        assertEquals(RESULT_WID_RETURN_EXTRACTED_PARAMETERS, wid1.getResults());
+        assertEquals(REST_WID_EXTRACTED_PARAMETERS, wid1.getParameters());
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/workitem/WorkItemDefinitionClientParserTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/workitem/WorkItemDefinitionClientParserTest.java
@@ -46,6 +46,7 @@ public class WorkItemDefinitionClientParserTest {
     private static final String SECOND_WID_IS_INCORRECT_WID_FILE = "org/kie/workbench/common/stunner/bpmn/client/workitem/secondWidIsIncorrect.wid";
     private static final String MVEL_LIST_IN_WID_FILE = "org/kie/workbench/common/stunner/bpmn/client/workitem/listParameters.wid";
     private static final String SINGLE_LINE_COMMENTS_FILE = "org/kie/workbench/common/stunner/bpmn/client/workitem/singleLineComments.wid";
+    private static final String MULTI_LINE_COMMENTS_FILE = "org/kie/workbench/common/stunner/bpmn/client/workitem/multiLineComments.wid";
 
     final static String EMAIL_WID_EXTRACTED_PARAMETERS = "|Body:String,From:String,Subject:String,To:String|";
     final static String RESULT_WID_RETURN_EXTRACTED_PARAMETERS = "|Result:java.lang.Object|";
@@ -220,6 +221,20 @@ public class WorkItemDefinitionClientParserTest {
     @Test
     public void testSingleLineComments() {
         String widFile = loadTestFile(SINGLE_LINE_COMMENTS_FILE);
+        List<WorkItemDefinition> defs = WorkItemDefinitionClientParser.parse(widFile);
+        assertEquals(1, defs.size());
+
+        WorkItemDefinition wid3 = defs.get(0);
+        assertEquals("Rest", wid3.getName());
+        assertEquals("REST", wid3.getDisplayName());
+        assertEquals("", wid3.getIconDefinition().getUri());
+        assertEquals(RESULT_WID_RETURN_EXTRACTED_PARAMETERS, wid3.getResults());
+        assertEquals(REST_WID_EXTRACTED_NOT_COMMENTED_PARAMETERS, wid3.getParameters());
+    }
+
+    @Test
+    public void testMultiLineComments() {
+        String widFile = loadTestFile(MULTI_LINE_COMMENTS_FILE);
         List<WorkItemDefinition> defs = WorkItemDefinitionClientParser.parse(widFile);
         assertEquals(1, defs.size());
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/resources/org/kie/workbench/common/stunner/bpmn/client/workitem/importPartIgnored.wid
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/resources/org/kie/workbench/common/stunner/bpmn/client/workitem/importPartIgnored.wid
@@ -1,0 +1,22 @@
+import something.package;
+import another.something;
+
+[
+    [
+      "name" : "Rest",
+      "parameters" : [
+          "ContentData" : new StringDataType(),
+          "Url" : new StringDataType(),
+          "Method" : new StringDataType(),
+          "ConnectTimeout" : new StringDataType(),
+          "ReadTimeout" : new StringDataType()   ,
+          "Username" : new StringDataType(),
+          "Password" : new StringDataType()
+      ],
+      "results" : [
+          "Result" : new ObjectDataType(),
+      ],
+      "displayName" : "REST",
+      "icon" : "defaultservicenodeicon.png"
+    ]
+]

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/resources/org/kie/workbench/common/stunner/bpmn/client/workitem/multiLineComments.wid
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/resources/org/kie/workbench/common/stunner/bpmn/client/workitem/multiLineComments.wid
@@ -1,0 +1,22 @@
+/* file to test comments
+*/
+[ /* comment */
+    [
+      "name" : "Rest",
+      "parameters" : [
+          /*"ContentData" : new StringDataType(),
+          "Url" : new StringDataType(), */
+          "Method" : new StringDataType(),/**/
+          "ConnectTimeout" : new StringDataType(), /*  */
+          "ReadTimeout" : new StringDataType()   /*,
+          "Username" : new StringDataType(),
+          "Password" : new StringDataType()*/
+      ],
+      "results" : [
+          "Result" : new ObjectDataType(),
+      ],
+      "displayName" : "REST"//,
+      /* "icon" : "defaultservicenodeicon.png" */
+    ]
+]
+/**/

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/resources/org/kie/workbench/common/stunner/bpmn/client/workitem/singleLineComments.wid
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/resources/org/kie/workbench/common/stunner/bpmn/client/workitem/singleLineComments.wid
@@ -1,0 +1,21 @@
+// file to test comments
+[ //comment
+    [
+      "name" : "Rest",
+      "parameters" : [
+          //"ContentData" : new StringDataType(),
+          // "Url" : new StringDataType(),
+          "Method" : new StringDataType(),//
+          "ConnectTimeout" : new StringDataType(), //
+          "ReadTimeout" : new StringDataType()   //,
+          //"Username" : new StringDataType(),
+          //"Password" : new StringDataType()
+      ],
+      "results" : [
+          "Result" : new ObjectDataType(),
+      ],
+      "displayName" : "REST"//,
+      // "icon" : "defaultservicenodeicon.png"
+    ]
+]
+//


### PR DESCRIPTION
Hi @romartin, @domhanak,

now it is possible to use comments (both single and multi line) and imports in WID files.

see [VS Code extension](https://drive.google.com/file/d/10tCqW6yruYsebGY9V-6JR88EMD6IGOcS/view?usp=sharing) for tests. Thank you!