### PR TITLE
KOGITO-5676: BPMN Editor - Containment not working when Node overlaps the Connector while splicing

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LineSpliceAcceptorControlImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LineSpliceAcceptorControlImplTest.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.client.lienzo.canvas.controls;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -26,8 +27,6 @@ import com.ait.lienzo.client.core.shape.wires.IContainmentAcceptor;
 import com.ait.lienzo.client.core.shape.wires.IDockingAcceptor;
 import com.ait.lienzo.client.core.shape.wires.ILineSpliceAcceptor;
 import com.ait.lienzo.client.core.shape.wires.WiresManager;
-import com.ait.lienzo.client.core.types.Point2D;
-import com.ait.lienzo.client.core.types.Point2DArray;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
@@ -130,7 +129,7 @@ public class LineSpliceAcceptorControlImplTest {
     @Captor
     private ArgumentCaptor<CompositeCommand<AbstractCanvasHandler, CanvasViolation>> commandsCapture;
 
-    private Point2D location = new Point2D(20, 20);
+    private double[] location = new double[]{20, 20};
 
     private LineSpliceAcceptorControlImpl tested;
 
@@ -278,16 +277,16 @@ public class LineSpliceAcceptorControlImplTest {
         setExecuteTrue();
 
         tested.init(canvasHandler);
-        Point2DArray firstHalfPoints = new Point2DArray();
-        Point2DArray secondHalfPoints = new Point2DArray();
-        Point2D CP0 = new Point2D(10, 10);
-        Point2D CP1 = new Point2D(20, 10);
-        Point2D CP2 = new Point2D(30, 10);
-        Point2D CP3 = new Point2D(40, 10);
-        firstHalfPoints.push(CP0);
-        firstHalfPoints.push(CP1);
-        secondHalfPoints.push(CP2);
-        secondHalfPoints.push(CP3);
+        List<double[]> firstHalfPoints = new ArrayList<>();
+        List<double[]> secondHalfPoints = new ArrayList<>();
+        double[] CP0 = new double[]{10, 10};
+        double[] CP1 = new double[]{20, 10};
+        double[] CP2 = new double[]{30, 10};
+        double[] CP3 = new double[]{40, 10};
+        firstHalfPoints.add(CP0);
+        firstHalfPoints.add(CP1);
+        secondHalfPoints.add(CP2);
+        secondHalfPoints.add(CP3);
 
         assertTrue(tested.accept(spliceNode,
                                  location,
@@ -328,20 +327,20 @@ public class LineSpliceAcceptorControlImplTest {
         setExecuteTrue();
 
         tested.init(canvasHandler);
-        Point2DArray firstHalfPoints = new Point2DArray();
-        Point2DArray secondHalfPoints = new Point2DArray();
-        Point2D CP0 = new Point2D(10, 10);
-        Point2D CP1 = new Point2D(20, 10);
-        Point2D CP2 = new Point2D(30, 10);
-        Point2D CP3 = new Point2D(40, 10);
-        Point2D CP4 = new Point2D(50, 10);
-        Point2D CP5 = new Point2D(60, 10);
-        firstHalfPoints.push(CP0);
-        firstHalfPoints.push(CP1);
-        firstHalfPoints.push(CP2);
-        firstHalfPoints.push(CP3);
-        secondHalfPoints.push(CP4);
-        secondHalfPoints.push(CP5);
+        List<double[]> firstHalfPoints = new ArrayList<>();
+        List<double[]> secondHalfPoints = new ArrayList<>();
+        double[] CP0 = new double[]{10, 10};
+        double[] CP1 = new double[]{20, 10};
+        double[] CP2 = new double[]{30, 10};
+        double[] CP3 = new double[]{40, 10};
+        double[] CP4 = new double[]{50, 10};
+        double[] CP5 = new double[]{60, 10};
+        firstHalfPoints.add(CP0);
+        firstHalfPoints.add(CP1);
+        firstHalfPoints.add(CP2);
+        firstHalfPoints.add(CP3);
+        secondHalfPoints.add(CP4);
+        secondHalfPoints.add(CP5);
 
         assertTrue(tested.accept(spliceNode,
                                  location,
@@ -382,16 +381,16 @@ public class LineSpliceAcceptorControlImplTest {
         setExecuteFalse();
 
         tested.init(canvasHandler);
-        Point2DArray firstHalfPoints = new Point2DArray();
-        Point2DArray secondHalfPoints = new Point2DArray();
-        Point2D CP0 = new Point2D(10, 10);
-        Point2D CP1 = new Point2D(20, 10);
-        Point2D CP2 = new Point2D(30, 10);
-        Point2D CP3 = new Point2D(40, 10);
-        firstHalfPoints.push(CP0);
-        firstHalfPoints.push(CP1);
-        secondHalfPoints.push(CP2);
-        secondHalfPoints.push(CP3);
+        List<double[]> firstHalfPoints = new ArrayList<>();
+        List<double[]> secondHalfPoints = new ArrayList<>();
+        double[] CP0 = new double[]{10, 10};
+        double[] CP1 = new double[]{20, 10};
+        double[] CP2 = new double[]{30, 10};
+        double[] CP3 = new double[]{40, 10};
+        firstHalfPoints.add(CP0);
+        firstHalfPoints.add(CP1);
+        secondHalfPoints.add(CP2);
+        secondHalfPoints.add(CP3);
 
         assertFalse(tested.accept(spliceNode,
                                   location,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/pom.xml
@@ -104,11 +104,6 @@
       <artifactId>appformer-client-api</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>lienzo-core</artifactId>
-    </dependency>
-
     <!-- Test scope. -->
 
     <dependency>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/LineSpliceAcceptorControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/LineSpliceAcceptorControl.java
@@ -16,8 +16,8 @@
 
 package org.kie.workbench.common.stunner.core.client.canvas.controls;
 
-import com.ait.lienzo.client.core.types.Point2D;
-import com.ait.lienzo.client.core.types.Point2DArray;
+import java.util.List;
+
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.RequiresCommandManager;
 import org.kie.workbench.common.stunner.core.graph.Edge;
@@ -29,15 +29,15 @@ public interface LineSpliceAcceptorControl<H extends CanvasHandler>
                 RequiresCommandManager<H> {
 
     boolean allow(Node spliceNode,
-                  Point2D location,
+                  double[] location,
                   Node parentNode,
                   Edge<ViewConnector<?>, Node> connector);
 
     boolean accept(Node spliceNode,
-                   Point2D location,
+                   double[] location,
                    Node parentNode,
                    Edge<ViewConnector<?>, Node> edge,
                    int controlPoints,
-                   final Point2DArray firstHalfPoints,
-                   final Point2DArray secondHalfPoints);
+                   List<double[]> firstHalfPoints,
+                   List<double[]> secondHalfPoints);
 }

--- a/lienzo-core/src/main/java/com/ait/lienzo/client/core/shape/wires/ILineSpliceAcceptor.java
+++ b/lienzo-core/src/main/java/com/ait/lienzo/client/core/shape/wires/ILineSpliceAcceptor.java
@@ -16,8 +16,7 @@
 
 package com.ait.lienzo.client.core.shape.wires;
 
-import com.ait.lienzo.client.core.types.Point2D;
-import com.ait.lienzo.client.core.types.Point2DArray;
+import java.util.List;
 
 public interface ILineSpliceAcceptor {
 
@@ -26,15 +25,15 @@ public interface ILineSpliceAcceptor {
     ILineSpliceAcceptor NONE = new DefaultLineSpliceAcceptor(false);
 
     boolean allowSplice(WiresShape shape,
-                        Point2D candidateLocation,
+                        double[] candidateLocation,
                         WiresConnector connector,
                         WiresContainer parent);
 
     boolean acceptSplice(WiresShape shape,
-                         Point2D candidateLocation,
+                         double[] candidateLocation,
                          WiresConnector connector,
-                         Point2DArray firstHalfPoints,
-                         Point2DArray secondHalfPoints,
+                         List<double[]> firstHalfPoints,
+                         List<double[]> secondHalfPoints,
                          WiresContainer parent);
 
     void ensureUnHighLight();
@@ -49,7 +48,7 @@ public interface ILineSpliceAcceptor {
 
         @Override
         public boolean allowSplice(WiresShape shape,
-                                   Point2D candidateLocation,
+                                   double[] candidateLocation,
                                    WiresConnector connector,
                                    WiresContainer parent) {
             return m_defaultValue;
@@ -57,14 +56,15 @@ public interface ILineSpliceAcceptor {
 
         @Override
         public boolean acceptSplice(WiresShape shape,
-                                    Point2D candidateLocation,
+                                    double[] candidateLocation,
                                     WiresConnector connector,
-                                    Point2DArray firstHalfPoints,
-                                    Point2DArray secondHalfPoints,
+                                    List<double[]> firstHalfPoints,
+                                    List<double[]> secondHalfPoints,
                                     WiresContainer parent) {
             return m_defaultValue;
         }
 
-        public void ensureUnHighLight() {}
+        public void ensureUnHighLight() {
+        }
     }
 }

--- a/lienzo-core/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresContainmentControlImpl.java
+++ b/lienzo-core/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresContainmentControlImpl.java
@@ -85,7 +85,8 @@ public class WiresContainmentControlImpl extends AbstractWiresControl<WiresConta
 
     @Override
     public Point2D getCandidateLocation() {
-        return calculateCandidateLocation(getParentPickerControl());
+        return calculateCandidateLocation(getParentPickerControl(),
+                                          getParentPickerControl().getParent());
     }
 
     @Override
@@ -136,9 +137,9 @@ public class WiresContainmentControlImpl extends AbstractWiresControl<WiresConta
         shape.setDockedTo(null);
     }
 
-    public static Point2D calculateCandidateLocation(final WiresParentPickerControl parentPickerControl) {
+    public static Point2D calculateCandidateLocation(final WiresParentPickerControl parentPickerControl,
+                                                     final WiresContainer parent) {
         final WiresLayer m_layer = parentPickerControl.getShape().getWiresManager().getLayer();
-        final WiresContainer parent = parentPickerControl.getParent();
         final Point2D current = parentPickerControl.getShapeLocation();
         if (parent == null || parent == m_layer) {
             return current;

--- a/lienzo-webapp/src/main/java/org/kie/lienzo/client/LineSpliceExample.java
+++ b/lienzo-webapp/src/main/java/org/kie/lienzo/client/LineSpliceExample.java
@@ -16,6 +16,8 @@
 
 package org.kie.lienzo.client;
 
+import java.util.List;
+
 import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.wires.IConnectionAcceptor;
 import com.ait.lienzo.client.core.shape.wires.IContainmentAcceptor;
@@ -30,7 +32,6 @@ import com.ait.lienzo.client.core.shape.wires.WiresManager;
 import com.ait.lienzo.client.core.shape.wires.WiresShape;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresShapeHighlightImpl;
 import com.ait.lienzo.client.core.types.Point2D;
-import com.ait.lienzo.client.core.types.Point2DArray;
 import com.ait.lienzo.client.widget.panel.LienzoPanel;
 import elemental2.dom.HTMLDivElement;
 
@@ -75,7 +76,7 @@ public class LineSpliceExample extends BaseExample implements Example {
         wiresManager.setLineSpliceAcceptor(new ILineSpliceAcceptor() {
             @Override
             public boolean allowSplice(WiresShape shape,
-                                       Point2D candidateLocation,
+                                       double[] candidateLocation,
                                        WiresConnector connector,
                                        WiresContainer parent) {
                 highlight.highlight(shape, PickerPart.ShapePart.BODY);
@@ -84,10 +85,10 @@ public class LineSpliceExample extends BaseExample implements Example {
 
             @Override
             public boolean acceptSplice(WiresShape shape,
-                                        Point2D candidateLocation,
+                                        double[] candidateLocation,
                                         WiresConnector connector,
-                                        Point2DArray firstHalfPoints,
-                                        Point2DArray secondHalfPoints,
+                                        List<double[]> firstHalfPoints,
+                                        List<double[]> secondHalfPoints,
                                         WiresContainer parent) {
                 highlight.restore();
                 return true;


### PR DESCRIPTION
Hey @romartin, please could you review this PR?

**JIRA**: [KOGITO-5676](https://issues.redhat.com/browse/KOGITO-5676)

**VS Code**: [plugin](https://drive.google.com/file/d/1yGvvu7NSdkIwhpgRHqrcYDOdXO4VF7uV/view?usp=sharing)

Thanks