### PR TITLE
KOGITO-5728: [DMN Designer] New Boxed Expression editor - Remove "|" grip from the new boxed expression editor

### DIFF
--- a/kogito-editors-js/packages/boxed-expression-component/src/components/Resizer/Resizer.css
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/Resizer/Resizer.css
@@ -28,28 +28,6 @@
   border: none;
 }
 
-.expression-container .pf-c-drawer .pf-c-drawer__splitter-handle::after {
-  border-left: none;
-  position: absolute;
-  left: -1px;
-  top: 50%;
-  border-color: var(--pf-global--palette--black-300);
-  transform: translateY(-50%);
-}
-
-.expression-container
-  .react-resizable
-  table
-  td:last-child
-  > .react-resizable
-  > .pf-c-drawer
-  .pf-c-drawer__splitter-handle::after,
-.expression-container
-  .react-resizable
-  table
-  th:last-child
-  > .react-resizable
-  > .pf-c-drawer
-  .pf-c-drawer__splitter-handle::after {
-  opacity: 0;
+.expression-container .pf-c-drawer__splitter-handle::after {
+  display: none;
 }


### PR DESCRIPTION
**Jira**: [KOGITO-5728](https://issues.redhat.com/browse/KOGITO-5728): [DMN Designer] New Boxed Expression editor - Remove "|" grip from the new boxed expression editor

![invisible-grip](https://user-images.githubusercontent.com/1079279/130032329-0c29c05c-ead3-4912-a2db-961a0e9f34ce.gif)
