### PR TITLE
KOGITO-5642 Fix CI job ID

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -24,7 +24,7 @@ Map getMultijobPRConfig() {
             parallel: true,
             jobs : [
                     [
-                            id: 'Kogito Tooling Editors Java',
+                            id: 'kogito-tooling-editors-java',
                             primary: true
                     ]
             ],


### PR DESCRIPTION
Folders in jenkins workspace are generated according to the job ID. Whitespaces in the ID causes an issues.