### PR TITLE
Setup GO lang in full downstream action

### DIFF
--- a/.github/workflows/ci_full_downstream_build.yml
+++ b/.github/workflows/ci_full_downstream_build.yml
@@ -95,6 +95,11 @@ jobs:
         with:
           node-version: 16.2.0
 
+      - name: "kogito-tooling :: Set up GOLANG 1.16"
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.16"
+
       - name: "kogito-tooling :: Setup Yarn"
         run: |
           npm install -g yarn@1.22.10


### PR DESCRIPTION
![Screenshot from 2021-09-14 16-28-27](https://user-images.githubusercontent.com/8044780/133276736-e128de71-f99b-4497-8f00-6b7eb6352358.png)

This is needed due to `kogito-tooling-go` was moved under `kogito-tooling`