### PR TITLE
KOGITO-5901: [DMN/BPMN/SceSim] Check dependabot alerts

### DIFF
--- a/appformer-bom/pom.xml
+++ b/appformer-bom/pom.xml
@@ -297,17 +297,6 @@
         </exclusions>
       </dependency>
 
-      <dependency>
-        <groupId>org.keycloak</groupId>
-        <artifactId>keycloak-core</artifactId>
-        <version>${version.org.keycloak}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.keycloak</groupId>
-        <artifactId>keycloak-common</artifactId>
-        <version>${version.org.keycloak}</version>
-      </dependency>
-
       <!-- GWT and GWT Extensions -->
       <dependency>
         <groupId>com.google.gwt</groupId>
@@ -485,18 +474,6 @@
         <groupId>org.kie.kogito</groupId>
         <artifactId>lienzo-tests</artifactId>
         <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>${version.org.apache.httpcomponents.httpclient}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>

--- a/errai-bom/pom.xml
+++ b/errai-bom/pom.xml
@@ -63,7 +63,6 @@
     <appengine.version>1.7.6</appengine.version>
     <asm.version>7.1</asm.version>
     <gmaven.mojo.version>1.5</gmaven.mojo.version>
-    <guava.version>29.0-jre</guava.version>
     <guice.version>3.0</guice.version>
     <gwt.phonegap.version>3.5.0.1</gwt.phonegap.version>
     <gwt.version>2.9.0</gwt.version>
@@ -96,13 +95,11 @@
     <!-- we can't use this due GWT hard dependency on api 1.x <version.jakarta.validation>2.0.2</version.jakarta.validation> -->
     <version.javax.validation>1.0.0.GA</version.javax.validation>
     <version.junit>4.13.1</version.junit>
-    <version.log4j>1.2.17</version.log4j>
 
     <version.org.apache.commons.lang3>3.8.1</version.org.apache.commons.lang3>
     <version.org.apache.deltaspike.core>1.5.1</version.org.apache.deltaspike.core>
     <version.org.apache.maven>3.3.9</version.org.apache.maven>
     <version.org.dom4j>2.1.3</version.org.dom4j>
-    <version.org.eclipse.jetty>9.2.14.v20151106</version.org.eclipse.jetty>
     <version.org.glassfish.javax.el>3.0.0</version.org.glassfish.javax.el>
     <version.org.hibernate>5.3.15.Final</version.org.hibernate>
     <version.org.hibernate.validator>4.1.0.Final</version.org.hibernate.validator>
@@ -137,7 +134,6 @@
     <version.org.jboss.weld.weld>3.1.5.SP1</version.org.jboss.weld.weld>
     <version.org.jboss.weld.weld-api>3.1.SP2</version.org.jboss.weld.weld-api>
     <version.org.jgroups>3.6.14.Final</version.org.jgroups>
-    <version.org.jsoup>1.8.3</version.org.jsoup>
     <version.org.lesscss>1.7.0.1.1</version.org.lesscss>
     <version.org.mockito>2.12.0</version.org.mockito>
     <version.org.mvel>2.4.8.Final</version.org.mvel>
@@ -316,29 +312,6 @@
         <version>${version.javax.persistence-api}</version>
       </dependency>
       <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>${version.log4j}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>ant</groupId>
-            <artifactId>ant-nodeps</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>ant-contrib</groupId>
-            <artifactId>ant-contrib</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>ant</groupId>
-            <artifactId>ant-junit</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>sun.jdk</groupId>
-            <artifactId>tools</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>org.apache.deltaspike.core</groupId>
         <artifactId>deltaspike-core-api</artifactId>
         <version>${version.org.apache.deltaspike.core}</version>
@@ -400,58 +373,6 @@
         <artifactId>hibernate-commons-annotations</artifactId>
         <version>${version.org.hibernate.commons.annotations}</version>
       </dependency>
-      <!-- Must come before gwt-dev -->
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-continuation</artifactId>
-        <version>${version.org.eclipse.jetty}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-webapp</artifactId>
-        <version>${version.org.eclipse.jetty}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-http</artifactId>
-        <version>${version.org.eclipse.jetty}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-io</artifactId>
-        <version>${version.org.eclipse.jetty}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-proxy</artifactId>
-        <version>${version.org.eclipse.jetty}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-security</artifactId>
-        <version>${version.org.eclipse.jetty}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-server</artifactId>
-        <version>${version.org.eclipse.jetty}</version>
-      </dependency>
-      <dependency>
-        <!-- This must be placed above com.google.gwt:gwt-dev to override the Jetty that is present there -->
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlet</artifactId>
-        <version>${version.org.eclipse.jetty}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlets</artifactId>
-        <version>${version.org.eclipse.jetty}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-util</artifactId>
-        <version>${version.org.eclipse.jetty}</version>
-      </dependency>
 
       <dependency>
         <groupId>org.codehaus.gmaven</groupId>
@@ -468,11 +389,6 @@
         <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
         <version>${version.org.javassist}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jsoup</groupId>
-        <artifactId>jsoup</artifactId>
-        <version>${version.org.jsoup}</version>
       </dependency>
       <dependency>
         <groupId>org.mvel</groupId>
@@ -739,16 +655,6 @@
             <artifactId>guava</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${guava.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava-gwt</artifactId>
-        <version>${guava.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/errai-bom/pom.xml
+++ b/errai-bom/pom.xml
@@ -100,7 +100,6 @@
 
     <version.org.apache.commons.lang3>3.8.1</version.org.apache.commons.lang3>
     <version.org.apache.deltaspike.core>1.5.1</version.org.apache.deltaspike.core>
-    <version.org.apache.httpcomponents.httpclient>4.5.3</version.org.apache.httpcomponents.httpclient>
     <version.org.apache.maven>3.3.9</version.org.apache.maven>
     <version.org.dom4j>2.1.3</version.org.dom4j>
     <version.org.eclipse.jetty>9.2.14.v20151106</version.org.eclipse.jetty>
@@ -139,8 +138,6 @@
     <version.org.jboss.weld.weld-api>3.1.SP2</version.org.jboss.weld.weld-api>
     <version.org.jgroups>3.6.14.Final</version.org.jgroups>
     <version.org.jsoup>1.8.3</version.org.jsoup>
-    <!-- Keycloak 9.0.3.Final can't be upgraded due API/class changes-->
-    <version.org.keycloak>1.9.4.Final</version.org.keycloak>
     <version.org.lesscss>1.7.0.1.1</version.org.lesscss>
     <version.org.mockito>2.12.0</version.org.mockito>
     <version.org.mvel>2.4.8.Final</version.org.mvel>
@@ -478,26 +475,6 @@
         <version>${version.org.jsoup}</version>
       </dependency>
       <dependency>
-        <groupId>org.keycloak</groupId>
-        <artifactId>keycloak-core</artifactId>
-        <version>${version.org.keycloak}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.keycloak</groupId>
-        <artifactId>keycloak-adapter-core</artifactId>
-        <version>${version.org.keycloak}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.keycloak</groupId>
-        <artifactId>keycloak-servlet-oauth-client</artifactId>
-        <version>${version.org.keycloak}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.keycloak</groupId>
-        <artifactId>keycloak-admin-client</artifactId>
-        <version>${version.org.keycloak}</version>
-      </dependency>
-      <dependency>
         <groupId>org.mvel</groupId>
         <artifactId>mvel2</artifactId>
         <version>${version.org.mvel}</version>
@@ -550,17 +527,6 @@
         <groupId>org.apache.stanbol</groupId>
         <artifactId>org.apache.stanbol.enhancer.engines.htmlextractor</artifactId>
         <version>${apache.stanbol.htmlextractor.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>${version.org.apache.httpcomponents.httpclient}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.ow2.asm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,8 @@
     <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
     <!-- Newer version in kie-parent causes ServiceLoader error -->
     <version.ch.qos.logback>1.1.3</version.ch.qos.logback>
+    <!-- Synchronized with GWT 2.9.0 -->
+    <version.org.eclipse.jetty>9.2.14.v20151106</version.org.eclipse.jetty>
     <version.org.uberfire.latestFinal.release>1.4.0.Final</version.org.uberfire.latestFinal.release>
     <revapi.oldUberFireVersion>${version.org.uberfire.latestFinal.release}</revapi.oldUberFireVersion>
     <revapi.newUberFireVersion>${project.version}</revapi.newUberFireVersion>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-5901

In this PR I managed all **depandabot** alerts. Please consider, all the involved dependencies are already managed in the parent pom `kie-parent`, so the common solution I adopted is to inherit the versions from that pom. In detail:

- **org.jsoup:jsoup**: Defined and managed in `kie-parent`. [A PR is already opened there to update the version](https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1731). I think we can safely refer to `kie-parent`, so I removed it.
- **org.apache.httpcomponents:httpclient**: Defined and managed in `kie-parent`. Already updated to the last version `4.5.13` due to this ([RHPAM-3234](https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1529)). Therefore, even if `GWT 2.9.0` refers to version `4.5.3`, I think we can safely use the last version, which is already inherited and used by this repo. Removed.
- **com.google.guava:guava**: Defined and managed in `kie-parent`. [A PR was merged to update the version](
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1620). I think we can safely refer to `kie-parent`, so I removed it.
- **log4j:log4j**: It seems not used in this repo - removed.
- **org.keycloak:keycloak-core**: It seems not used in this repo - removed.
- **org.eclipse.jetty**: Defined and managed in `kie-parent`. [A PR was merged to update the version](https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1679). Well, in this case, I'm not sure we should inherit the newer version from `kie-parent`. `GWT 2.9.0` refers to the old version `9.2.14.v20151106`.  Therefore, for this case, I prefer forcing using the old version, in order to guarantee a better stability. (newer version in 6 years after that). But I'm open for suggestions!

