### PR TITLE
KOGITO-5909: [DMN Designer] New Boxed Expression editor - DMN Expression column width is updated too many times in some scenarios

### DIFF
--- a/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/Resizer/dom/Cell.test.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/Resizer/dom/Cell.test.tsx
@@ -28,6 +28,12 @@ let cell: Cell;
 let element: HTMLElement;
 let container: Element;
 
+const EMPTY_LIST_OF_NODES = {
+  length: 0,
+  item: (_index: number) => document.createElement("span"),
+  forEach: (_element: any) => ({}),
+};
+
 describe("Cell", () => {
   beforeAll(() => {
     document.dispatchEvent = jest.fn();
@@ -118,6 +124,61 @@ describe("Cell", () => {
     it("returns false when the literal expression does not live in the last column", () => {
       act(renderLiteralAtRegularColumn);
       expect(cell.isLastColumn()).toBeFalsy();
+    });
+  });
+
+  describe("refreshWidthAsLastGroupColumn", () => {
+    describe("when cell has children", () => {
+      beforeEach(() => {
+        Element.prototype.getBoundingClientRect = jest.fn(() => {
+          return {
+            x: 4,
+            y: 8,
+            width: 16,
+            height: 32,
+            top: 64,
+            left: 128,
+            bottom: 256,
+            right: 512,
+          } as DOMRect;
+        });
+        createContextWithInnerDecisionTable();
+      });
+
+      it("returns the inner width", () => {
+        const elements = container.querySelectorAll(CELL_CSS_SELECTOR);
+        const cellElement = elements.item(7) as HTMLElement;
+        const cell = new Cell(cellElement, [], 1);
+        const setWidthSpy = jest.spyOn(cell, "setWidth");
+
+        cell.refreshWidthAsLastGroupColumn();
+
+        expect(setWidthSpy).toBeCalledWith(506);
+      });
+    });
+
+    describe("when cell doesn't have children", () => {
+      beforeEach(() => {
+        Element.prototype.querySelectorAll = jest.fn((selector): NodeListOf<HTMLElement> => {
+          if (selector === ".input") {
+            return EMPTY_LIST_OF_NODES;
+          }
+          return document.querySelectorAll(selector);
+        });
+
+        createContextWithInnerDecisionTable();
+      });
+
+      it("returns the inner width", () => {
+        const elements = container.querySelectorAll(CELL_CSS_SELECTOR);
+        const cellElement = elements.item(7) as HTMLElement;
+        const cell = new Cell(cellElement, [], 1);
+        const setWidthSpy = jest.spyOn(cell, "setWidth");
+
+        cell.refreshWidthAsLastGroupColumn();
+
+        expect(setWidthSpy).not.toBeCalled();
+      });
     });
   });
 });
@@ -232,6 +293,101 @@ function createContext() {
           },
           entryInfoWidth: 150,
           entryExpressionWidth: 1468,
+        } as unknown as ContextProps)}
+      />
+    ).wrapper
+  ).container;
+}
+
+function createContextWithInnerDecisionTable() {
+  container = render(
+    usingTestingBoxedExpressionI18nContext(
+      <ContextExpression
+        {...({
+          uid: "id1",
+          logicType: "Context",
+          name: "Expression Name",
+          dataType: "<Undefined>",
+          contextEntries: [
+            {
+              entryInfo: {
+                name: "ContextEntry-1",
+                dataType: "<Undefined>",
+              },
+              entryExpression: {
+                uid: "id2",
+                logicType: "Context",
+                contextEntries: [
+                  {
+                    entryInfo: {
+                      name: "ContextEntry-1",
+                      dataType: "<Undefined>",
+                    },
+                    entryExpression: {
+                      uid: "id4",
+                      logicType: "Context",
+                      contextEntries: [
+                        {
+                          entryInfo: {
+                            name: "ContextEntry-1",
+                            dataType: "<Undefined>",
+                          },
+                          entryExpression: {
+                            uid: "id6",
+                            logicType: "Decision Table",
+                            name: "ContextEntry-1",
+                            dataType: "<Undefined>",
+                            hitPolicy: "UNIQUE",
+                            aggregation: "",
+                            input: [
+                              {
+                                name: "input-1",
+                                dataType: "<Undefined>",
+                              },
+                            ],
+                            output: [
+                              {
+                                name: "output-1",
+                                dataType: "<Undefined>",
+                              },
+                            ],
+                            annotations: [
+                              {
+                                name: "annotation-1",
+                              },
+                            ],
+                            rules: [
+                              {
+                                inputEntries: ["-"],
+                                outputEntries: [""],
+                                annotationEntries: [""],
+                              },
+                            ],
+                          },
+                          editInfoPopoverLabel: "Edit Context Entry",
+                          nameAndDataTypeSynchronized: true,
+                        },
+                      ],
+                      result: {
+                        uid: "id7",
+                      },
+                    },
+                    editInfoPopoverLabel: "Edit Context Entry",
+                    nameAndDataTypeSynchronized: true,
+                  },
+                ],
+                result: {
+                  uid: "id5",
+                },
+              },
+              editInfoPopoverLabel: "Edit Context Entry",
+              nameAndDataTypeSynchronized: true,
+            },
+          ],
+          result: {
+            uid: "id3",
+          },
+          isHeadless: false,
         } as unknown as ContextProps)}
       />
     ).wrapper

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/Resizer/Resizer.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/Resizer/Resizer.tsx
@@ -72,6 +72,10 @@ export const Resizer: React.FunctionComponent<ResizerProps> = ({
   useLayoutEffect(() => {
     function listener(event: CustomEvent) {
       const width = Math.round(event.detail.width);
+      if (width === resizerWidth) {
+        return;
+      }
+
       setResizerWidth(width);
       onHorizontalResizeStop?.(width);
     }

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/Resizer/dom/Cell.ts
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/Resizer/dom/Cell.ts
@@ -86,6 +86,11 @@ export class Cell {
 
     const children = [].slice.call((refSibling as HTMLElement).querySelectorAll(`.${this.getHeaderType()}`));
     const childrenRects = children.map((c: HTMLElement) => c.getBoundingClientRect());
+
+    if (childrenRects.length === 0) {
+      return;
+    }
+
     const x = Math.min(...childrenRects.map((c: DOMRect) => c.x));
     const right = Math.max(...childrenRects.map((c: DOMRect) => c.right));
 


### PR DESCRIPTION
Jira: [KOGITO-5909](https://issues.redhat.com/browse/KOGITO-5909): [DMN Designer] New Boxed Expression editor - DMN Expression column width is updated too many times in some scenarios

**Before:**
<img width="50%" src="https://user-images.githubusercontent.com/1079279/134003464-a9d333a7-06e0-4e54-ade7-9b2b53b920a4.gif"/>

**After:**
<img width="50%" src="https://user-images.githubusercontent.com/1079279/134003458-f4d4c3c7-e360-4ac9-8730-ddc453c483bd.gif"/>
