### PR TITLE
KOGITO-6033: Make DMN data types documentation entries readable

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/template/dmn-documentation-template.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/template/dmn-documentation-template.html
@@ -158,7 +158,6 @@
             vertical-align: middle;
             font-weight: bold;
             padding-right: 5px;
-            width: 25%;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;


### PR DESCRIPTION
For more details see:
- https://issues.redhat.com/browse/KOGITO-6033

### before
![Screenshot from 2021-10-01 09-08-32](https://user-images.githubusercontent.com/8044780/135580686-fae720f5-d372-4d73-a9e3-9098af0be682.png)

### after
![Screenshot from 2021-10-01 09-09-03](https://user-images.githubusercontent.com/8044780/135580701-fc94ad6f-620a-432f-945a-6c6edc34828b.png)
