### PR TITLE
KOGITO-6021: [DMN Designer] Multiple DRDs - Renaming a DRD freezes the browser

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/drd/DRDNameChangerView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/drd/DRDNameChangerView.java
@@ -137,7 +137,9 @@ public class DRDNameChangerView implements DRDNameChanger {
     }
 
     private void performSave(final DMNDiagramElement dmnDiagramElement) {
-        dmnDiagramElement.getName().setValue(drdNameInput.getValue());
-        selectedEvent.fire(new DMNDiagramSelected(dmnDiagramElement));
+        if (!dmnDiagramElement.getName().getValue().equals(drdNameInput.getValue())) {
+            dmnDiagramElement.getName().setValue(drdNameInput.getValue());
+            selectedEvent.fire(new DMNDiagramSelected(dmnDiagramElement));
+        }
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/drd/DRDNameChangerView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/drd/DRDNameChangerView.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.dmn.client.editors.drd;
 
+import java.util.Objects;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
@@ -135,7 +137,7 @@ public class DRDNameChangerView implements DRDNameChanger {
     }
 
     private void performSave(final DMNDiagramElement dmnDiagramElement) {
-        if (!dmnDiagramElement.getName().getValue().equals(drdNameInput.getValue())) {
+        if (!Objects.equals(dmnDiagramElement.getName().getValue(), drdNameInput.getValue())) {
             dmnDiagramElement.getName().setValue(drdNameInput.getValue());
             selectedEvent.fire(new DMNDiagramSelected(dmnDiagramElement));
         } else {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/drd/DRDNameChangerView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/drd/DRDNameChangerView.java
@@ -100,8 +100,7 @@ public class DRDNameChangerView implements DRDNameChanger {
             hideDRDNameChanger();
         } else {
             this.drdName.setText(selected.getDiagramElement().getName().getValue());
-            editMode.getStyle().setDisplay(NONE);
-            viewMode.getStyle().setDisplay(BLOCK);
+            enableEditMode(false);
             showDRDNameChanger();
         }
     }
@@ -115,8 +114,7 @@ public class DRDNameChangerView implements DRDNameChanger {
     @EventHandler("viewMode")
     void enableEdit(final ClickEvent event) {
         drdNameInput.setValue(drdName.getText());
-        viewMode.getStyle().setDisplay(NONE);
-        editMode.getStyle().setDisplay(BLOCK);
+        enableEditMode(true);
         drdNameInput.focus();
     }
 
@@ -140,6 +138,13 @@ public class DRDNameChangerView implements DRDNameChanger {
         if (!dmnDiagramElement.getName().getValue().equals(drdNameInput.getValue())) {
             dmnDiagramElement.getName().setValue(drdNameInput.getValue());
             selectedEvent.fire(new DMNDiagramSelected(dmnDiagramElement));
+        } else {
+            enableEditMode(false);
         }
+    }
+
+    private void enableEditMode(boolean enabled) {
+        viewMode.getStyle().setDisplay(enabled ? NONE : BLOCK);
+        editMode.getStyle().setDisplay(enabled ? BLOCK : NONE);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/drd/DRDNameChangerViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/drd/DRDNameChangerViewTest.java
@@ -160,14 +160,32 @@ public class DRDNameChangerViewTest {
     }
 
     @Test
-    public void testSaveForTheCurrentDiagram() {
+    public void testSaveForTheCurrentDiagramChangedValue() {
+        String originalValue = "original";
+        String nameValue = "changed";
+
+        testSaveForTheCurrentDiagram(originalValue, nameValue);
+    }
+
+    @Test
+    public void testSaveForTheCurrentDiagramSameValue() {
+        String originalValue = "original";
+
+        testSaveForTheCurrentDiagram(originalValue, originalValue);
+    }
+
+    private void testSaveForTheCurrentDiagram(String originalValue, String nameValue) {
+        Name nameMock = mock(Name.class);
+        boolean changed = !originalValue.equals(nameValue);
+
         when(dmnDiagramsSession.getCurrentDMNDiagramElement()).thenReturn(Optional.of(dmnDiagramElement));
-        when(dmnDiagramElement.getName()).thenReturn(new Name());
+        when(dmnDiagramElement.getName()).thenReturn(nameMock);
+        when(drdNameInput.getValue()).thenReturn(nameValue);
+        when(nameMock.getValue()).thenReturn(originalValue);
 
         drdNameChangerView.saveForTheCurrentDiagram();
 
-        verify(drdNameInput, times(1)).getValue();
-        verify(selectedEvent, times(1)).fire(any(DMNDiagramSelected.class));
+        verify(nameMock, times(changed ? 1 : 0)).setValue(nameValue);
+        verify(selectedEvent, times(changed ? 1 : 0)).fire(any(DMNDiagramSelected.class));
     }
-
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/drd/DRDNameChangerViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/drd/DRDNameChangerViewTest.java
@@ -41,7 +41,10 @@ import org.kie.workbench.common.stunner.client.widgets.presenters.session.Sessio
 import org.mockito.Mock;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -82,7 +85,10 @@ public class DRDNameChangerViewTest {
     private DMNDiagramElement dmnDiagramElement;
 
     @Mock
-    private Style style;
+    private Style viewStyle;
+
+    @Mock
+    private Style editStyle;
 
     @Mock
     private ClickEvent clickEvent;
@@ -95,11 +101,11 @@ public class DRDNameChangerViewTest {
 
     @Before
     public void setUp() {
-        when(editMode.getStyle()).thenReturn(style);
-        when(viewMode.getStyle()).thenReturn(style);
+        when(editMode.getStyle()).thenReturn(editStyle);
+        when(viewMode.getStyle()).thenReturn(viewStyle);
         when(dmnDiagramsSession.getCurrentDMNDiagramElement()).thenReturn(Optional.empty());
 
-        drdNameChangerView = new DRDNameChangerView(dmnDiagramsSession, selectedEvent, viewMode, editMode, returnToDRG, drdName, drdNameInput);
+        drdNameChangerView = spy(new DRDNameChangerView(dmnDiagramsSession, selectedEvent, viewMode, editMode, returnToDRG, drdName, drdNameInput));
         drdNameChangerView.setSessionPresenterView(sessionPresenterView);
     }
 
@@ -110,6 +116,13 @@ public class DRDNameChangerViewTest {
         drdNameChangerView.onSettingCurrentDMNDiagramElement(dmnDiagramSelected);
 
         verify(dmnDiagramsSession, times(2)).isGlobalGraphSelected();
+        verify(drdNameChangerView, times(1)).hideDRDNameChanger();
+        // One call is on setup method
+        verify(drdNameChangerView, times(1)).showDRDNameChanger();
+        verify(drdName, times(0)).setText(anyString());
+
+        verify(viewStyle, never()).setDisplay(any());
+        verify(editStyle, never()).setDisplay(any());
     }
 
     @Test
@@ -121,6 +134,12 @@ public class DRDNameChangerViewTest {
         drdNameChangerView.onSettingCurrentDMNDiagramElement(dmnDiagramSelected);
 
         verify(dmnDiagramsSession, times(2)).isGlobalGraphSelected();
+        verify(drdNameChangerView, times(0)).hideDRDNameChanger();
+        // One call is on setup method
+        verify(drdNameChangerView, times(2)).showDRDNameChanger();
+        verify(drdName, times(1)).setText("");
+        verify(viewStyle, times(1)).setDisplay(Style.Display.BLOCK);
+        verify(editStyle, times(1)).setDisplay(Style.Display.NONE);
     }
 
     @Test
@@ -139,6 +158,8 @@ public class DRDNameChangerViewTest {
 
         verify(drdNameInput, times(1)).setValue(spanText);
         verify(drdNameInput, times(1)).focus();
+        verify(viewStyle, times(1)).setDisplay(Style.Display.NONE);
+        verify(editStyle, times(1)).setDisplay(Style.Display.BLOCK);
     }
 
     @Test
@@ -187,5 +208,7 @@ public class DRDNameChangerViewTest {
 
         verify(nameMock, times(changed ? 1 : 0)).setValue(nameValue);
         verify(selectedEvent, times(changed ? 1 : 0)).fire(any(DMNDiagramSelected.class));
+        verify(viewStyle, times(changed ? 0 : 1)).setDisplay(changed ? any() : Style.Display.BLOCK);
+        verify(editStyle, times(changed ? 0 : 1)).setDisplay(changed ? any() : Style.Display.NONE);
     }
 }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-6021

Steps to reproduce: 
- Create a Decision Node;
- Click on DRD Action -> Create
- Try to update the `new-diagram` that appeared above (Press ENTER when the new value is assigned)
- Browser freezes

Fix: During every rename action, a process is fired to update the reference in multiple places of the editor.  This process is fired when the user press ENTER in the input element OR the input element loses focus (blur) (eg. pressing in another point of the page).
Unfortunately, pressing ENTER will start the process and at its end, a blur event is fired duplicating the process which leads eventually to freeze the browser.
To fix it, I start the rename update process ONLY if the new value is different than the original.

