### PR TITLE
KOGITO-6045 - Scroll automatically expandable canvas

### DIFF
--- a/lienzo-core/src/main/java/com/ait/lienzo/client/widget/DragContext.java
+++ b/lienzo-core/src/main/java/com/ait/lienzo/client/widget/DragContext.java
@@ -40,39 +40,43 @@ import com.ait.lienzo.shared.core.types.NodeType;
  */
 public class DragContext {
 
-    private int m_evtx;
+    protected int m_evtx;
 
-    private int m_evty;
+    protected int m_evty;
 
-    private int m_dstx;
+    protected int m_dstx;
 
-    private int m_dsty;
+    protected int m_dsty;
 
-    private double m_lstx;
+    protected double m_offsetx;
 
-    private double m_lsty;
+    protected double m_offsety;
 
-    private final Transform m_gtol;
+    protected double m_lstx;
 
-    private final Transform m_ltog;
+    protected double m_lsty;
 
-    private final Transform m_vtog;
+    protected final Transform m_gtol;
 
-    private final IPrimitive<?> m_prim;
+    protected final Transform m_ltog;
 
-    private final double m_prmx;
+    protected final Transform m_vtog;
 
-    private final double m_prmy;
+    protected final IPrimitive<?> m_prim;
 
-    private final int m_begx;
+    protected final double m_prmx;
 
-    private final int m_begy;
+    protected final double m_prmy;
 
-    private final DragConstraintEnforcer m_drag;
+    protected final int m_begx;
 
-    private final Point2D m_lclp = new Point2D(0, 0);
+    protected final int m_begy;
 
-    private final Point2D m_pref = new Point2D(0, 0);
+    protected final DragConstraintEnforcer m_drag;
+
+    protected final Point2D m_lclp = new Point2D(0, 0);
+
+    protected final Point2D m_pref = new Point2D(0, 0);
 
     /**
      * Starts a drag operation for the specified node.
@@ -145,7 +149,7 @@ public class DragContext {
      *
      * @return double
      */
-    private final double getNodeParentsAlpha(Node<?> node) {
+    protected final double getNodeParentsAlpha(Node<?> node) {
         double alpha = 1;
 
         node = node.getParent();
@@ -169,10 +173,30 @@ public class DragContext {
      * @param x
      * @param y
      */
-    public void dragUpdate(final int x, final int y) {
+    public void dragMoveUpdate(final int x, final int y) {
         m_evtx = x;
 
         m_evty = y;
+
+        dragUpdate();
+    }
+
+    /**
+     * Updates the context for the specified Drag Offset event.
+     * Used internally.
+     *
+     * @param offsetX
+     * @param offsetY
+     */
+    public void dragOffsetUpdate(final double offsetX, final double offsetY) {
+        m_offsetx += offsetX;
+
+        m_offsety += offsetY;
+
+        dragUpdate();
+    }
+
+    protected void dragUpdate() {
 
         m_dstx = m_evtx - m_begx;
 
@@ -182,15 +206,14 @@ public class DragContext {
 
         m_gtol.transform(new Point2D(m_dstx, m_dsty), p2);
 
-        m_lclp.setX(p2.getX() - m_pref.getX());
+        m_lclp.setX(p2.getX() + m_offsetx - m_pref.getX());
 
-        m_lclp.setY(p2.getY() - m_pref.getY());
-
-        // Let the constraints adjust the location if necessary
+        m_lclp.setY(p2.getY() + m_offsety - m_pref.getY());
 
         if (m_drag != null) {
             m_drag.adjust(m_lclp);
         }
+
         final double localX = m_prmx + m_lclp.getX();
 
         final double localY = m_prmy + m_lclp.getY();
@@ -201,8 +224,6 @@ public class DragContext {
         if (m_lsty != localY) {
             m_prim.setY(m_lsty = localY);
         }
-        //Console.get().info("2) m_prim " + m_evtx + ":" + m_evty + ":" + m_dstx + " : " + m_dsty + " : " + p2 + " : " + m_lclp + " : " + m_prim.getLocation());
-
     }
 
     /**
@@ -268,6 +289,24 @@ public class DragContext {
      */
     public int getEventY() {
         return m_evty;
+    }
+
+    /**
+     * Returns the horizontsal offset - i.e. event(x,y) of last drag offset
+     *
+     * @return
+     */
+    public double getOffsetX() {
+        return m_offsetx;
+    }
+
+    /**
+     * Returns the vertical offset - i.e. event(x,y) of last drag offset
+     *
+     * @return
+     */
+    public double getOffsetY() {
+        return m_offsety;
     }
 
     /**
@@ -349,12 +388,21 @@ public class DragContext {
     }
 
     /**
+     * Returns the offset - i.e. last drag offset
+     *
+     * @return
+     */
+    public Point2D getOffset() {
+        return new Point2D(getOffsetX(), getOffsetY());
+    }
+
+    /**
      * Returns the distance between the start and end in viewport coordinates
      *
      * @return
      */
     public Point2D getDistanceAdjusted() {
-        return getEventAdjusted().sub(getStartAdjusted());
+        return getEventAdjusted().add(getOffset()).sub(getStartAdjusted());
     }
 
     /**

--- a/lienzo-core/src/main/java/com/ait/lienzo/client/widget/panel/impl/LienzoPanelDragLimitEventDetail.java
+++ b/lienzo-core/src/main/java/com/ait/lienzo/client/widget/panel/impl/LienzoPanelDragLimitEventDetail.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ait.lienzo.client.widget.panel.impl;
+
+import java.util.Set;
+
+import com.ait.lienzo.client.widget.panel.LienzoPanel;
+import elemental2.dom.CustomEvent;
+import elemental2.dom.Event;
+
+public class LienzoPanelDragLimitEventDetail extends LienzoPanelEventDetail {
+
+    public enum LimitDirections {
+        LEFT,
+        RIGHT,
+        TOP,
+        DOWN
+    }
+
+    private Set<LimitDirections> limitDirection;
+
+    public static LienzoPanelDragLimitEventDetail getDragLimitDetail(Event event) {
+        return (LienzoPanelDragLimitEventDetail) ((CustomEvent) event).detail;
+    }
+
+    public LienzoPanelDragLimitEventDetail(LienzoPanel panel, Set<LimitDirections> limitDirection) {
+        super(panel);
+        this.limitDirection = limitDirection;
+    }
+
+    public Set<LimitDirections> getLimitDirection() {
+        return limitDirection;
+    }
+}

--- a/lienzo-core/src/main/java/com/ait/lienzo/client/widget/panel/impl/LienzoPanelEvents.java
+++ b/lienzo-core/src/main/java/com/ait/lienzo/client/widget/panel/impl/LienzoPanelEvents.java
@@ -1,6 +1,10 @@
 package com.ait.lienzo.client.widget.panel.impl;
 
+import java.util.EnumSet;
+
+import com.ait.lienzo.client.core.shape.IPrimitive;
 import com.ait.lienzo.client.widget.panel.LienzoPanel;
+import com.ait.lienzo.client.widget.panel.impl.LienzoPanelDragLimitEventDetail.LimitDirections;
 import elemental2.dom.CustomEvent;
 import elemental2.dom.EventListener;
 
@@ -11,6 +15,12 @@ public class LienzoPanelEvents {
     static final String LIENZO_PANEL_RESIZE_EVENT = "lienzoPanelResizeEvent";
     static final String LIENZO_PANEL_SCALE_EVENT = "lienzoPanelScaleEvent";
     static final String LIENZO_PANEL_SCROLL_EVENT = "lienzoPanelScrollEvent";
+    static final String LIENZO_PANEL_PRIMITIVE_DRAG_START_EVENT = "lienzoPanelPrimitiveDragStartEvent";
+    static final String LIENZO_PANEL_PRIMITIVE_DRAG_MOVE_UPDATE_EVENT = "lienzoPanelPrimitiveDragMoveUpdateEvent";
+    static final String LIENZO_PANEL_PRIMITIVE_DRAG_OFFSET_UPDATE_EVENT = "lienzoPanelPrimitiveDragOffsetUpdateEvent";
+    static final String LIENZO_PANEL_PRIMITIVE_DRAG_END_EVENT = "lienzoPanelPrimitiveDragEndEvent";
+    static final String LIENZO_PANEL_DRAG_LIMITS_OVER_EVENT = "lienzoPanelDragLimitsOverEvent";
+    static final String LIENZO_PANEL_DRAG_LIMITS_OUT_EVENT = "lienzoPanelDragLimitsOutEvent";
 
     static void addBoundsChangedEventListener(LienzoPanel panel,
                                               EventListener eventListener) {
@@ -71,15 +81,117 @@ public class LienzoPanelEvents {
         fireCustomEvent(LIENZO_PANEL_SCROLL_EVENT, panel, detail);
     }
 
-    private static void fireCustomEvent(String eventType,
-                                        LienzoPanel panel) {
+    static void addPrimitiveDragStartEventListener(LienzoPanel<? extends LienzoPanel> panel,
+                                                   EventListener eventListener) {
+        panel.getElement().addEventListener(LIENZO_PANEL_PRIMITIVE_DRAG_START_EVENT, eventListener);
+    }
+
+    static void removePrimitiveDragStartEventListener(LienzoPanel<? extends LienzoPanel> panel,
+                                                      EventListener eventListener) {
+        panel.getElement().removeEventListener(LIENZO_PANEL_PRIMITIVE_DRAG_START_EVENT, eventListener);
+    }
+
+    static void firePrimitiveDragStartEvent(LienzoPanel<? extends LienzoPanel> panel,
+                                            IPrimitive<?> primitive,
+                                            double dragX,
+                                            double dragY) {
+        LienzoPanelPrimitiveDragEventDetail detail = new LienzoPanelPrimitiveDragEventDetail(panel, primitive, dragX, dragY);
+        fireCustomEvent(LIENZO_PANEL_PRIMITIVE_DRAG_START_EVENT, panel, detail);
+    }
+
+    static void addPrimitiveDragMoveUpdateEventListener(LienzoPanel<? extends LienzoPanel> panel,
+                                                        EventListener eventListener) {
+        panel.getElement().addEventListener(LIENZO_PANEL_PRIMITIVE_DRAG_MOVE_UPDATE_EVENT, eventListener);
+    }
+
+    static void removePrimitiveDragMoveUpdateEventListener(LienzoPanel<? extends LienzoPanel> panel,
+                                                           EventListener eventListener) {
+        panel.getElement().removeEventListener(LIENZO_PANEL_PRIMITIVE_DRAG_MOVE_UPDATE_EVENT, eventListener);
+    }
+
+    static void firePrimitiveDragMoveUpdateEvent(LienzoPanel<? extends LienzoPanel> panel,
+                                                 IPrimitive<?> primitive,
+                                                 double dragX,
+                                                 double dragY) {
+        LienzoPanelPrimitiveDragEventDetail detail = new LienzoPanelPrimitiveDragEventDetail(panel, primitive, dragX, dragY);
+        fireCustomEvent(LIENZO_PANEL_PRIMITIVE_DRAG_MOVE_UPDATE_EVENT, panel, detail);
+    }
+
+    static void addPrimitiveDragOffsetUpdateEventListener(LienzoPanel<? extends LienzoPanel> panel,
+                                                          EventListener eventListener) {
+        panel.getElement().addEventListener(LIENZO_PANEL_PRIMITIVE_DRAG_OFFSET_UPDATE_EVENT, eventListener);
+    }
+
+    static void removePrimitiveDragOffsetUpdateEventListener(LienzoPanel<? extends LienzoPanel> panel,
+                                                             EventListener eventListener) {
+        panel.getElement().removeEventListener(LIENZO_PANEL_PRIMITIVE_DRAG_OFFSET_UPDATE_EVENT, eventListener);
+    }
+
+    static void firePrimitiveDragOffsetUpdateEvent(LienzoPanel<? extends LienzoPanel> panel,
+                                                   IPrimitive<?> primitive,
+                                                   double dragX,
+                                                   double dragY) {
+        LienzoPanelPrimitiveDragEventDetail detail = new LienzoPanelPrimitiveDragEventDetail(panel, primitive, dragX, dragY);
+        fireCustomEvent(LIENZO_PANEL_PRIMITIVE_DRAG_OFFSET_UPDATE_EVENT, panel, detail);
+    }
+
+    static void addPrimitiveDragEndEventListener(LienzoPanel<? extends LienzoPanel> panel,
+                                                 EventListener eventListener) {
+        panel.getElement().addEventListener(LIENZO_PANEL_PRIMITIVE_DRAG_END_EVENT, eventListener);
+    }
+
+    static void removePrimitiveDragEndEventListener(LienzoPanel<? extends LienzoPanel> panel,
+                                                    EventListener eventListener) {
+        panel.getElement().removeEventListener(LIENZO_PANEL_PRIMITIVE_DRAG_END_EVENT, eventListener);
+    }
+
+    static void firePrimitiveDragEndEvent(LienzoPanel<? extends LienzoPanel> panel,
+                                          IPrimitive<?> primitive,
+                                          double dragX,
+                                          double dragY) {
+        LienzoPanelPrimitiveDragEventDetail detail = new LienzoPanelPrimitiveDragEventDetail(panel, primitive, dragX, dragY);
+        fireCustomEvent(LIENZO_PANEL_PRIMITIVE_DRAG_END_EVENT, panel, detail);
+    }
+
+    static void addDragLimitsOverEventListener(LienzoPanel panel,
+                                               EventListener eventListener) {
+        panel.getElement().addEventListener(LIENZO_PANEL_DRAG_LIMITS_OVER_EVENT, eventListener);
+    }
+
+    static void removeDragLimitsOverEventListener(LienzoPanel panel,
+                                                  EventListener eventListener) {
+        panel.getElement().removeEventListener(LIENZO_PANEL_DRAG_LIMITS_OVER_EVENT, eventListener);
+    }
+
+    static void fireDragLimitsOverEvent(LienzoPanel panel,
+                                        EnumSet<LimitDirections> limitDirections) {
+        LienzoPanelDragLimitEventDetail detail = new LienzoPanelDragLimitEventDetail(panel, limitDirections);
+        fireCustomEvent(LIENZO_PANEL_DRAG_LIMITS_OVER_EVENT, panel, detail);
+    }
+
+    static void addDragLimitsOutEventListener(LienzoPanel panel,
+                                              EventListener eventListener) {
+        panel.getElement().addEventListener(LIENZO_PANEL_DRAG_LIMITS_OUT_EVENT, eventListener);
+    }
+
+    static void removeDragLimitsOutEventListener(LienzoPanel panel,
+                                                 EventListener eventListener) {
+        panel.getElement().removeEventListener(LIENZO_PANEL_DRAG_LIMITS_OUT_EVENT, eventListener);
+    }
+
+    static void fireDragLimitsOutEvent(LienzoPanel panel) {
+        fireCustomEvent(LIENZO_PANEL_DRAG_LIMITS_OUT_EVENT, panel);
+    }
+
+    protected static void fireCustomEvent(String eventType,
+                                          LienzoPanel panel) {
         LienzoPanelEventDetail detail = new LienzoPanelEventDetail(panel);
         fireCustomEvent(eventType, panel, detail);
     }
 
-    private static void fireCustomEvent(String eventType,
-                                        LienzoPanel panel,
-                                        LienzoPanelEventDetail detail) {
+    protected static void fireCustomEvent(String eventType,
+                                          LienzoPanel panel,
+                                          LienzoPanelEventDetail detail) {
         CustomEvent event = new CustomEvent(eventType);
         event.initCustomEvent(eventType, true, false, detail);
         panel.getElement().dispatchEvent(event);

--- a/lienzo-core/src/main/java/com/ait/lienzo/client/widget/panel/impl/LienzoPanelHandlerManager.java
+++ b/lienzo-core/src/main/java/com/ait/lienzo/client/widget/panel/impl/LienzoPanelHandlerManager.java
@@ -16,6 +16,7 @@
 package com.ait.lienzo.client.widget.panel.impl;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import com.ait.lienzo.client.core.event.AbstractNodeHumanInputEvent;
@@ -45,9 +46,11 @@ import com.ait.lienzo.client.core.shape.Shape;
 import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.client.widget.DragContext;
 import com.ait.lienzo.client.widget.panel.LienzoPanel;
+import com.ait.lienzo.client.widget.panel.impl.LienzoPanelDragLimitEventDetail.LimitDirections;
 import com.ait.lienzo.gwtlienzo.event.shared.EventHandler;
 import com.ait.lienzo.shared.core.types.DragMode;
 import com.ait.lienzo.shared.core.types.EventPropagationMode;
+import com.ait.lienzo.tools.client.Timer;
 import com.ait.lienzo.tools.client.collection.NFastArrayList;
 import com.ait.lienzo.tools.client.event.EventType;
 import com.ait.lienzo.tools.client.event.HandlerRegistrationManager;
@@ -65,6 +68,9 @@ import elemental2.dom.UIEvent;
 import jsinterop.base.Js;
 
 public final class LienzoPanelHandlerManager {
+
+    private static final double DRAG_BOUNDS_INCREMENT = 15;
+    private static final int DRAG_TIMER_INTERVAL = 50;
 
     private final LienzoPanel m_lienzo;
 
@@ -92,11 +98,23 @@ public final class LienzoPanelHandlerManager {
 
     private boolean m_mouse_button_right = false;
 
+    private IPrimitive<?> m_over_prim = null;
+
     private DragMode m_drag_mode = null;
+
+    private int lastDragMoveX;
+
+    private int lastDragMoveY;
+
+    private MouseEvent lastDragMouseEvent;
+
+    private TouchEvent lastDragTouchEvent;
 
     private IPrimitive<?> m_drag_node = null;
 
-    private IPrimitive<?> m_over_prim = null;
+    private Timer dragLimitsTimer;
+
+    private Set<LimitDirections> dragLimitsDirection;
 
     private DragContext m_dragContext;
 
@@ -111,6 +129,7 @@ public final class LienzoPanelHandlerManager {
         m_mediators = m_viewport.getMediators();
 
         handlerRegistrationManager = new HandlerRegistrationManager();
+        initializeDragBoundsTimer();
         addHandlers();
     }
 
@@ -444,6 +463,21 @@ public final class LienzoPanelHandlerManager {
             event.preventDefault();
         });
 
+        LienzoPanelEvents.addDragLimitsOverEventListener(m_lienzo, (Event event) -> {
+            LienzoPanelDragLimitEventDetail detail = LienzoPanelDragLimitEventDetail.getDragLimitDetail(event);
+            dragLimitsDirection = detail.getLimitDirection();
+            if (!dragLimitsTimer.isRunning()) {
+                dragLimitsTimer.scheduleRepeating(DRAG_TIMER_INTERVAL);
+            }
+        });
+
+        LienzoPanelEvents.addDragLimitsOutEventListener(m_lienzo, (Event event) -> {
+            dragLimitsDirection.clear();
+            if (dragLimitsTimer.isRunning()) {
+                dragLimitsTimer.cancel();
+            }
+        });
+
         // TODO: @FIXME Elemental2 does not provide Gesture support, so disabling this for now (mdp)
 //        handlerRegistrationManager.register (
 //            m_lienzo.addGestureStartHandler(new GestureStartHandler()
@@ -522,9 +556,40 @@ public final class LienzoPanelHandlerManager {
         return m_viewport.findShapeAtPoint(x, y);
     }
 
+    private final void initializeDragBoundsTimer() {
+        dragLimitsTimer = new Timer() {
+            @Override
+            public void run() {
+                double offsetX = 0;
+
+                double offsetY = 0;
+
+                if (dragLimitsDirection.contains(LimitDirections.LEFT)) {
+                    offsetX = -DRAG_BOUNDS_INCREMENT;
+                }
+                if (dragLimitsDirection.contains(LimitDirections.RIGHT)) {
+                    offsetX = DRAG_BOUNDS_INCREMENT;
+                }
+                if (dragLimitsDirection.contains(LimitDirections.TOP)) {
+                    offsetY = -DRAG_BOUNDS_INCREMENT;
+                }
+                if (dragLimitsDirection.contains(LimitDirections.DOWN)) {
+                    offsetY = DRAG_BOUNDS_INCREMENT;
+                }
+
+                doDragOffset(offsetX, offsetY);
+            }
+        };
+    }
+
     private final void doDragCancel(int x, int y, final MouseEvent mouseEvent, final TouchEvent touchEvent) {
         if (m_dragging) {
             doDragMove(x, y, mouseEvent, touchEvent);
+
+            if (dragLimitsTimer.isRunning()) {
+                dragLimitsDirection.clear();
+                dragLimitsTimer.cancel();
+            }
 
             // TODO: Cursor stuff   .
             /*Cursor cursor = m_lienzo.getNormalCursor();
@@ -546,6 +611,8 @@ public final class LienzoPanelHandlerManager {
             m_lienzo.setCursor(cursor);*/
 
             fireEvent(mouseEvent, touchEvent, x, y, m_dragContext, m_drag_node.asNode(), nodeDragEndEvent);
+
+            LienzoPanelEvents.firePrimitiveDragEndEvent(m_lienzo, m_drag_node, x, y);
 
             m_dragContext.dragDone();
 
@@ -598,6 +665,8 @@ public final class LienzoPanelHandlerManager {
 
         m_drag_node.setDragging(true);
 
+        LienzoPanelEvents.firePrimitiveDragStartEvent(m_lienzo, m_drag_node, x, y);
+
         fireEvent(mouseEvent, touchEvent, x, y, m_dragContext, node, nodeDragStartEvent);
 
         m_dragging = true;
@@ -614,12 +683,54 @@ public final class LienzoPanelHandlerManager {
         m_dragging_using_touches = touchEvent != null;
     }
 
-    private final void doDragMove(int x, int y, final MouseEvent mouseEvent, final TouchEvent touchEvent) {
-        m_dragContext.dragUpdate(x, y);
+    private final void doDragMove(final int x, final int y, final MouseEvent mouseEvent, final TouchEvent touchEvent) {
+        lastDragMoveX = x;
+
+        lastDragMoveY = y;
+
+        lastDragMouseEvent = mouseEvent;
+
+        lastDragTouchEvent = touchEvent;
+
+        m_dragContext.dragMoveUpdate(x, y);
+
+        if (dragLimitsDirection != null) {
+            dragLimitsDirection.clear();
+        }
+        if (dragLimitsTimer.isRunning()) {
+            dragLimitsTimer.cancel();
+        }
+
+        LienzoPanelEvents.firePrimitiveDragMoveUpdateEvent(m_lienzo, m_drag_node, x, y);
 
         if (m_dragging_dispatch_move) {
             fireEvent(mouseEvent, touchEvent, x, y, m_dragContext, m_drag_node.asNode(), nodeDragMoveEvent);
         }
+
+        if (DragMode.DRAG_LAYER == m_drag_mode) {
+            m_viewport.getDragLayer().draw();
+
+            m_dragContext.drawNodeWithTransforms(m_viewport.getDragLayer().getContext());
+        } else {
+            m_drag_node.getLayer().batch();
+        }
+    }
+
+    private final void doDragOffset(final double offsetX, final double offsetY) {
+        m_dragContext.dragOffsetUpdate(offsetX, offsetY);
+
+        LienzoPanelEvents.firePrimitiveDragOffsetUpdateEvent(m_lienzo, m_drag_node, offsetX, offsetY);
+
+        if (m_dragging_dispatch_move) {
+            fireEvent(lastDragMouseEvent,
+                      lastDragTouchEvent,
+                      lastDragMoveX,
+                      lastDragMoveY,
+                      m_dragContext,
+                      m_drag_node.asNode(),
+                      nodeDragMoveEvent);
+        }
+
         if (DragMode.DRAG_LAYER == m_drag_mode) {
             m_viewport.getDragLayer().draw();
 

--- a/lienzo-core/src/main/java/com/ait/lienzo/client/widget/panel/impl/LienzoPanelPrimitiveDragEventDetail.java
+++ b/lienzo-core/src/main/java/com/ait/lienzo/client/widget/panel/impl/LienzoPanelPrimitiveDragEventDetail.java
@@ -1,0 +1,41 @@
+package com.ait.lienzo.client.widget.panel.impl;
+
+import com.ait.lienzo.client.core.shape.IPrimitive;
+import com.ait.lienzo.client.widget.panel.LienzoPanel;
+import elemental2.dom.CustomEvent;
+import elemental2.dom.Event;
+
+public class LienzoPanelPrimitiveDragEventDetail extends LienzoPanelEventDetail {
+
+    private final double dragX;
+
+    private final double dragY;
+
+    private final IPrimitive<?> primitive;
+
+    public static LienzoPanelPrimitiveDragEventDetail getDragDetail(Event event) {
+        return (LienzoPanelPrimitiveDragEventDetail) ((CustomEvent) event).detail;
+    }
+
+    public LienzoPanelPrimitiveDragEventDetail(LienzoPanel<? extends LienzoPanel> panel,
+                                               IPrimitive<?> primitive,
+                                               double dragX,
+                                               double dragY) {
+        super(panel);
+        this.primitive = primitive;
+        this.dragX = dragX;
+        this.dragY = dragY;
+    }
+
+    public IPrimitive getPrimitive() {
+        return primitive;
+    }
+
+    public double getDragX() {
+        return dragX;
+    }
+
+    public double getDragY() {
+        return dragY;
+    }
+}

--- a/lienzo-tests/src/test/java/com/ait/lienzo/client/widget/DragContextTest.java
+++ b/lienzo-tests/src/test/java/com/ait/lienzo/client/widget/DragContextTest.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ait.lienzo.client.widget;
+
+import com.ait.lienzo.client.core.Context2D;
+import com.ait.lienzo.client.core.shape.IPrimitive;
+import com.ait.lienzo.client.core.shape.Node;
+import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.lienzo.client.core.types.Transform;
+import com.ait.lienzo.shared.core.types.NodeType;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class DragContextTest {
+
+    private final double ALPHA = 50;
+    private final int DRAG_START_X = 10;
+    private final int DRAG_START_Y = 20;
+    private final double PRIM_X = 15;
+    private final double PRIM_Y = 25;
+
+    @Mock
+    private IPrimitive<?> primitive;
+
+    @Mock
+    private Node node;
+
+    @Mock
+    private Node parentNode;
+
+    private DragContext tested;
+
+    @Before
+    public void setUp() {
+        when(primitive.asNode()).thenReturn(node);
+        when(primitive.getParent()).thenReturn(parentNode);
+        when(primitive.getX()).thenReturn(PRIM_X);
+        when(primitive.getY()).thenReturn(PRIM_Y);
+        when(node.getParent()).thenReturn(parentNode);
+        when(parentNode.getAbsoluteTransform()).thenReturn(new Transform());
+        when(parentNode.getParent()).thenReturn(null);
+        when(parentNode.getAlpha()).thenReturn(ALPHA);
+        when(parentNode.getNodeType()).thenReturn(NodeType.LAYER);
+
+        tested = spy(new DragContext(DRAG_START_X, DRAG_START_Y, primitive));
+    }
+
+    @Test
+    public void testDrawNodeWithTransforms() {
+        Context2D context = mock(Context2D.class);
+        tested.drawNodeWithTransforms(context);
+        verify(context).save();
+        verify(context).transform(tested.m_ltog);
+        verify(primitive).drawWithTransforms(context, ALPHA, null);
+        verify(context).restore();
+    }
+
+    @Test
+    public void testGetNodeParentsAlpha() {
+        double expected1 = 1;
+        Node node1 = mock(Node.class);
+        when(node1.getParent()).thenReturn(null);
+
+        double expected2 = 0.75;
+        Node node2 = mock(Node.class);
+        Node parentNode2 = mock(Node.class);
+        when(node2.getParent()).thenReturn(parentNode2);
+        when(parentNode2.getParent()).thenReturn(null);
+        when(parentNode2.getAlpha()).thenReturn(expected2);
+        when(parentNode2.getNodeType()).thenReturn(NodeType.LAYER);
+
+        double expected3 = 0.125;
+        double parentAlpha3 = 0.5;
+        double grandparentAlpha3 = 0.25;
+        Node node3 = mock(Node.class);
+        Node parentNode3 = mock(Node.class);
+        Node grandparentNode3 = mock(Node.class);
+        when(node3.getParent()).thenReturn(parentNode3);
+        when(parentNode3.getAlpha()).thenReturn(parentAlpha3);
+        when(parentNode3.getParent()).thenReturn(grandparentNode3);
+        when(grandparentNode3.getAlpha()).thenReturn(grandparentAlpha3);
+        when(grandparentNode3.getNodeType()).thenReturn(NodeType.GROUP);
+        when(grandparentNode3.getParent()).thenReturn(null);
+
+        double expected4 = 0.7;
+        double grandparentAlpha4 = 0.4;
+        Node node4 = mock(Node.class);
+        Node parentNode4 = mock(Node.class);
+        Node grandparentNode4 = mock(Node.class);
+        when(node4.getParent()).thenReturn(parentNode4);
+        when(parentNode4.getAlpha()).thenReturn(expected4);
+        when(parentNode4.getParent()).thenReturn(grandparentNode4);
+        when(grandparentNode4.getAlpha()).thenReturn(grandparentAlpha4);
+        when(grandparentNode4.getNodeType()).thenReturn(NodeType.LAYER);
+        when(grandparentNode4.getParent()).thenReturn(null);
+
+        double result1 = tested.getNodeParentsAlpha(node1);
+        assertEquals(expected1, result1, Double.MIN_NORMAL);
+
+        double result2 = tested.getNodeParentsAlpha(node2);
+        assertEquals(expected2, result2, Double.MIN_NORMAL);
+
+        double result3 = tested.getNodeParentsAlpha(node3);
+        assertEquals(expected3, result3, Double.MIN_NORMAL);
+
+        double result4 = tested.getNodeParentsAlpha(node4);
+        assertEquals(expected4, result4, Double.MIN_NORMAL);
+    }
+
+    @Test
+    public void testDragMoveUpdate() {
+        int x = 20;
+        int y = 30;
+
+        tested.dragMoveUpdate(x, y);
+        assertEquals(x, tested.m_evtx);
+        assertEquals(y, tested.m_evty);
+        verify(tested).dragUpdate();
+    }
+
+    @Test
+    public void testDragOffsetUpdate() {
+        int offsetX = 40;
+        int offsetY = 50;
+
+        tested.dragMoveUpdate(offsetX, offsetY);
+        assertEquals(offsetX, tested.m_evtx);
+        assertEquals(offsetY, tested.m_evty);
+        verify(tested).dragUpdate();
+    }
+
+    @Test
+    public void testDragUpdate() {
+        tested.m_evtx = 15;
+        tested.m_evty = 25;
+        tested.m_offsetx = 5;
+        tested.m_offsety = 35;
+        tested.dragUpdate();
+
+        assertEquals(tested.m_evtx - tested.m_begx, tested.m_dstx);
+        assertEquals(tested.m_evty - tested.m_begy, tested.m_dsty);
+
+        verify(tested.m_prim).setX(tested.m_prmx + tested.m_lclp.getX());
+        verify(tested.m_prim).setY(tested.m_prmy + tested.m_lclp.getY());
+    }
+
+    @Test
+    public void testDragDone() {
+        tested.m_lstx = PRIM_X;
+        tested.m_lsty = PRIM_Y;
+        tested.dragDone();
+        verify(tested.m_prim, never()).setX(anyDouble());
+
+        tested.m_lstx = 10;
+        tested.m_lsty = 15;
+        tested.dragDone();
+        verify(tested.m_prim).setX(tested.m_prmx + tested.m_lclp.getX());
+        verify(tested.m_prim).setY(tested.m_prmy + tested.m_lclp.getY());
+    }
+
+    @Test
+    public void testReset() {
+        tested.reset();
+        verify(tested.m_prim).setX(tested.m_prmx);
+        verify(tested.m_prim).setY(tested.m_prmy);
+    }
+
+    @Test
+    public void testGetDragStartX() {
+        assertEquals(tested.m_begx, tested.getDragStartX(), Double.MIN_NORMAL);
+    }
+
+    @Test
+    public void testGetDragStartY() {
+        assertEquals(tested.m_begy, tested.getDragStartY(), Double.MIN_NORMAL);
+    }
+
+    @Test
+    public void testGetEventX() {
+        assertEquals(tested.m_evtx, tested.getEventX(), Double.MIN_NORMAL);
+    }
+
+    @Test
+    public void testGetEventY() {
+        assertEquals(tested.m_evty, tested.getEventY(), Double.MIN_NORMAL);
+    }
+
+    @Test
+    public void testGetOffsetX() {
+        assertEquals(tested.m_offsetx, tested.getOffsetX(), Double.MIN_NORMAL);
+    }
+
+    @Test
+    public void testGetOffsetY() {
+        assertEquals(tested.m_offsety, tested.getOffsetY(), Double.MIN_NORMAL);
+    }
+
+    @Test
+    public void testGetDx() {
+        assertEquals(tested.m_dstx, tested.getDx(), Double.MIN_NORMAL);
+    }
+
+    @Test
+    public void testGetDy() {
+        assertEquals(tested.m_dsty, tested.getDy(), Double.MIN_NORMAL);
+    }
+
+    @Test
+    public void testGetGlobalToLocal() {
+        assertEquals(tested.m_gtol, tested.getGlobalToLocal());
+    }
+
+    @Test
+    public void testGetLocalToGlobal() {
+        assertEquals(tested.m_ltog, tested.getLocalToGlobal());
+    }
+
+    @Test
+    public void testGetViewportToGlobal() {
+        assertEquals(tested.m_vtog, tested.getViewportToGlobal());
+    }
+
+    @Test
+    public void testGetLocalAdjusted() {
+        assertEquals(tested.m_lclp, tested.getLocalAdjusted());
+    }
+
+    @Test
+    public void testGetStartAdjusted() {
+        Point2D result = tested.getStartAdjusted();
+        assertEquals(DRAG_START_X, result.getX(), Double.MIN_NORMAL);
+        assertEquals(DRAG_START_Y, result.getY(), Double.MIN_NORMAL);
+    }
+
+    @Test
+    public void testGetEventAdjusted() {
+        int expectedX = 16;
+        int expectedY = 7;
+        tested.m_evtx = expectedX;
+        tested.m_evty = expectedY;
+
+        Point2D result = tested.getEventAdjusted();
+        assertEquals(expectedX, result.getX(), Double.MIN_NORMAL);
+        assertEquals(expectedY, result.getY(), Double.MIN_NORMAL);
+    }
+
+    @Test
+    public void testGetOffset() {
+        int expectedX = 16;
+        int expectedY = 7;
+        tested.m_offsetx = expectedX;
+        tested.m_offsety = expectedY;
+
+        Point2D result = tested.getOffset();
+        assertEquals(expectedX, result.getX(), Double.MIN_NORMAL);
+        assertEquals(expectedY, result.getY(), Double.MIN_NORMAL);
+    }
+
+    @Test
+    public void testGetDistanceAdjusted() {
+        tested.m_evtx = 15;
+        tested.m_evty = 13;
+        tested.m_offsetx = 22;
+        tested.m_offsety = 25;
+
+        Point2D result = tested.getDistanceAdjusted();
+        assertEquals(27, result.getX(), Double.MIN_NORMAL);
+        assertEquals(18, result.getY(), Double.MIN_NORMAL);
+    }
+
+    @Test
+    public void testGetNode() {
+        assertEquals(tested.m_prim, tested.getNode());
+    }
+
+    @Test
+    public void testGetDragConstraints() {
+        assertEquals(tested.m_drag, tested.getDragConstraints());
+    }
+}

--- a/lienzo-tests/src/test/java/com/ait/lienzo/client/widget/panel/impl/LienzoPanelDragLimitEventDetailTest.java
+++ b/lienzo-tests/src/test/java/com/ait/lienzo/client/widget/panel/impl/LienzoPanelDragLimitEventDetailTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ait.lienzo.client.widget.panel.impl;
+
+import java.util.EnumSet;
+
+import com.ait.lienzo.client.widget.panel.LienzoPanel;
+import com.ait.lienzo.client.widget.panel.impl.LienzoPanelDragLimitEventDetail.LimitDirections;
+import elemental2.dom.CustomEvent;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+
+public class LienzoPanelDragLimitEventDetailTest {
+
+    private final EnumSet<LimitDirections> LIMIT_DIRECTIONS = EnumSet.allOf(LimitDirections.class);
+    private final String CUSTOM_EVENT_TYPE = "LIENZO EVENT TYPE";
+
+    @Mock
+    private LienzoPanel<? extends LienzoPanel> lienzoPanel;
+
+    private LienzoPanelDragLimitEventDetail tested;
+
+    @Before
+    public void setup() {
+        tested = new LienzoPanelDragLimitEventDetail(lienzoPanel,
+                                                     LIMIT_DIRECTIONS);
+    }
+
+    @Test
+    public void testGetDragDetail() {
+        CustomEvent<?> customEvent = createCustomEvent();
+        assertEquals(tested, LienzoPanelDragLimitEventDetail.getDragLimitDetail(customEvent));
+    }
+
+    @Test
+    public void testGetLienzoPanel() {
+        assertEquals(lienzoPanel, tested.getLienzoPanel());
+    }
+
+    @Test
+    public void testGetLimitDirection() {
+        assertEquals(LIMIT_DIRECTIONS, tested.getLimitDirection());
+    }
+
+    private CustomEvent<?> createCustomEvent() {
+        CustomEvent event = new CustomEvent(CUSTOM_EVENT_TYPE);
+        event.detail = tested;
+        return event;
+    }
+}

--- a/lienzo-tests/src/test/java/com/ait/lienzo/client/widget/panel/impl/LienzoPanelEventsTest.java
+++ b/lienzo-tests/src/test/java/com/ait/lienzo/client/widget/panel/impl/LienzoPanelEventsTest.java
@@ -1,0 +1,271 @@
+package com.ait.lienzo.client.widget.panel.impl;
+
+import java.util.EnumSet;
+
+import com.ait.lienzo.client.core.shape.IPrimitive;
+import com.ait.lienzo.client.widget.panel.LienzoPanel;
+import com.ait.lienzo.client.widget.panel.impl.LienzoPanelDragLimitEventDetail.LimitDirections;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import elemental2.dom.Event;
+import elemental2.dom.EventListener;
+import elemental2.dom.HTMLDivElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static com.ait.lienzo.client.widget.panel.impl.LienzoPanelEvents.LIENZO_PANEL_BOUNDS_CHANGED_EVENT;
+import static com.ait.lienzo.client.widget.panel.impl.LienzoPanelEvents.LIENZO_PANEL_DRAG_LIMITS_OUT_EVENT;
+import static com.ait.lienzo.client.widget.panel.impl.LienzoPanelEvents.LIENZO_PANEL_DRAG_LIMITS_OVER_EVENT;
+import static com.ait.lienzo.client.widget.panel.impl.LienzoPanelEvents.LIENZO_PANEL_PRIMITIVE_DRAG_END_EVENT;
+import static com.ait.lienzo.client.widget.panel.impl.LienzoPanelEvents.LIENZO_PANEL_PRIMITIVE_DRAG_MOVE_UPDATE_EVENT;
+import static com.ait.lienzo.client.widget.panel.impl.LienzoPanelEvents.LIENZO_PANEL_PRIMITIVE_DRAG_OFFSET_UPDATE_EVENT;
+import static com.ait.lienzo.client.widget.panel.impl.LienzoPanelEvents.LIENZO_PANEL_PRIMITIVE_DRAG_START_EVENT;
+import static com.ait.lienzo.client.widget.panel.impl.LienzoPanelEvents.LIENZO_PANEL_RESIZE_EVENT;
+import static com.ait.lienzo.client.widget.panel.impl.LienzoPanelEvents.LIENZO_PANEL_SCALE_EVENT;
+import static com.ait.lienzo.client.widget.panel.impl.LienzoPanelEvents.LIENZO_PANEL_SCROLL_EVENT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class LienzoPanelEventsTest {
+
+    @Mock
+    private LienzoPanel<? extends LienzoPanel> lienzoPanel;
+
+    @Mock
+    private HTMLDivElement htmlDivElement;
+
+    @Before
+    public void setup() {
+        when(lienzoPanel.getElement()).thenReturn(htmlDivElement);
+    }
+
+    @Test
+    public void testAddBoundsChangedEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addBoundsChangedEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).addEventListener(LIENZO_PANEL_BOUNDS_CHANGED_EVENT, eventListener);
+    }
+
+    @Test
+    public void testRemoveBoundsChangedEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.removeBoundsChangedEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).removeEventListener(LIENZO_PANEL_BOUNDS_CHANGED_EVENT, eventListener);
+    }
+
+    @Test
+    public void testFireBoundsChangedEvent() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addBoundsChangedEventListener(lienzoPanel, eventListener);
+        LienzoPanelEvents.fireBoundsChangedEvent(lienzoPanel);
+        verify(htmlDivElement).dispatchEvent(any(Event.class));
+    }
+
+    @Test
+    public void testAddResizeEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addResizeEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).addEventListener(LIENZO_PANEL_RESIZE_EVENT, eventListener);
+    }
+
+    @Test
+    public void testRemoveResizeEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.removeResizeEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).removeEventListener(LIENZO_PANEL_RESIZE_EVENT, eventListener);
+    }
+
+    @Test
+    public void testFireResizeEvent() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addBoundsChangedEventListener(lienzoPanel, eventListener);
+        LienzoPanelEvents.fireResizeEvent(lienzoPanel);
+        verify(htmlDivElement).dispatchEvent(any(Event.class));
+    }
+
+    @Test
+    public void testAddScaleEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addScaleEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).addEventListener(LIENZO_PANEL_SCALE_EVENT, eventListener);
+    }
+
+    @Test
+    public void testRemoveScaleEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.removeScaleEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).removeEventListener(LIENZO_PANEL_SCALE_EVENT, eventListener);
+    }
+
+    @Test
+    public void testFireScaleEvent() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addBoundsChangedEventListener(lienzoPanel, eventListener);
+        LienzoPanelEvents.fireScaleEvent(lienzoPanel);
+        verify(htmlDivElement).dispatchEvent(any(Event.class));
+    }
+
+    @Test
+    public void testAddScrollEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addScrollEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).addEventListener(LIENZO_PANEL_SCROLL_EVENT, eventListener);
+    }
+
+    @Test
+    public void testRemoveScrollEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.removeScrollEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).removeEventListener(LIENZO_PANEL_SCROLL_EVENT, eventListener);
+    }
+
+    @Test
+    public void testFireScrollEvent() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addBoundsChangedEventListener(lienzoPanel, eventListener);
+        LienzoPanelEvents.fireScrollEvent(lienzoPanel, 0, 0);
+        verify(htmlDivElement).dispatchEvent(any(Event.class));
+    }
+
+    @Test
+    public void testAddPrimitiveDragStartEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addPrimitiveDragStartEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).addEventListener(LIENZO_PANEL_PRIMITIVE_DRAG_START_EVENT, eventListener);
+    }
+
+    @Test
+    public void testRemovePrimitiveDragStartEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.removePrimitiveDragStartEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).removeEventListener(LIENZO_PANEL_PRIMITIVE_DRAG_START_EVENT, eventListener);
+    }
+
+    @Test
+    public void testFirePrimitiveDragStartEvent() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addBoundsChangedEventListener(lienzoPanel, eventListener);
+        LienzoPanelEvents.firePrimitiveDragStartEvent(lienzoPanel, mock(IPrimitive.class), 0, 0);
+        verify(htmlDivElement).dispatchEvent(any(Event.class));
+    }
+
+    @Test
+    public void testAddPrimitiveDragMoveUpdateEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addPrimitiveDragMoveUpdateEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).addEventListener(LIENZO_PANEL_PRIMITIVE_DRAG_MOVE_UPDATE_EVENT, eventListener);
+    }
+
+    @Test
+    public void testRemovePrimitiveDragMoveUpdateEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.removePrimitiveDragMoveUpdateEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).removeEventListener(LIENZO_PANEL_PRIMITIVE_DRAG_MOVE_UPDATE_EVENT, eventListener);
+    }
+
+    @Test
+    public void testFirePrimitiveDragMoveUpdateEvent() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addBoundsChangedEventListener(lienzoPanel, eventListener);
+        LienzoPanelEvents.firePrimitiveDragMoveUpdateEvent(lienzoPanel, mock(IPrimitive.class), 0, 0);
+        verify(htmlDivElement).dispatchEvent(any(Event.class));
+    }
+
+    @Test
+    public void testAddPrimitiveDragOffsetUpdateEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addPrimitiveDragOffsetUpdateEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).addEventListener(LIENZO_PANEL_PRIMITIVE_DRAG_OFFSET_UPDATE_EVENT, eventListener);
+    }
+
+    @Test
+    public void testRemovePrimitiveDragOffsetUpdateEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.removePrimitiveDragOffsetUpdateEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).removeEventListener(LIENZO_PANEL_PRIMITIVE_DRAG_OFFSET_UPDATE_EVENT, eventListener);
+    }
+
+    @Test
+    public void testFirePrimitiveDragOffsetUpdateEvent() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addBoundsChangedEventListener(lienzoPanel, eventListener);
+        LienzoPanelEvents.firePrimitiveDragOffsetUpdateEvent(lienzoPanel, mock(IPrimitive.class), 0, 0);
+        verify(htmlDivElement).dispatchEvent(any(Event.class));
+    }
+
+    @Test
+    public void testAddPrimitiveDragEndEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addPrimitiveDragEndEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).addEventListener(LIENZO_PANEL_PRIMITIVE_DRAG_END_EVENT, eventListener);
+    }
+
+    @Test
+    public void testRemovePrimitiveDragEndEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.removePrimitiveDragEndEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).removeEventListener(LIENZO_PANEL_PRIMITIVE_DRAG_END_EVENT, eventListener);
+    }
+
+    @Test
+    public void testFirePrimitiveDragEndEvent() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addBoundsChangedEventListener(lienzoPanel, eventListener);
+        LienzoPanelEvents.firePrimitiveDragEndEvent(lienzoPanel, mock(IPrimitive.class), 0, 0);
+        verify(htmlDivElement).dispatchEvent(any(Event.class));
+    }
+
+    @Test
+    public void testAddDragLimitsOverEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addDragLimitsOverEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).addEventListener(LIENZO_PANEL_DRAG_LIMITS_OVER_EVENT, eventListener);
+    }
+
+    @Test
+    public void testRemoveDragLimitsOverEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.removeDragLimitsOverEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).removeEventListener(LIENZO_PANEL_DRAG_LIMITS_OVER_EVENT, eventListener);
+    }
+
+    @Test
+    public void testFireDragLimitsOverEvent() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addDragLimitsOverEventListener(lienzoPanel, eventListener);
+        LienzoPanelEvents.fireDragLimitsOverEvent(lienzoPanel, EnumSet.allOf(LimitDirections.class));
+        verify(htmlDivElement).dispatchEvent(any(Event.class));
+    }
+
+    @Test
+    public void testAddDragLimitsOutEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addDragLimitsOutEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).addEventListener(LIENZO_PANEL_DRAG_LIMITS_OUT_EVENT, eventListener);
+    }
+
+    @Test
+    public void testRemoveDragLimitsOutEventListener() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.removeDragLimitsOutEventListener(lienzoPanel, eventListener);
+        verify(htmlDivElement).removeEventListener(LIENZO_PANEL_DRAG_LIMITS_OUT_EVENT, eventListener);
+    }
+
+    @Test
+    public void testFireDragLimitsOutEvent() {
+        EventListener eventListener = mock(EventListener.class);
+        LienzoPanelEvents.addDragLimitsOutEventListener(lienzoPanel, eventListener);
+        LienzoPanelEvents.fireDragLimitsOutEvent(lienzoPanel);
+        verify(htmlDivElement).dispatchEvent(any(Event.class));
+    }
+
+    @Test
+    public void testFireCustomEvent() {
+        LienzoPanelEvents.fireCustomEvent("CUSTOM_EVENT_TYPE", lienzoPanel, mock(LienzoPanelEventDetail.class));
+        verify(htmlDivElement).dispatchEvent(any(Event.class));
+    }
+}

--- a/lienzo-tests/src/test/java/com/ait/lienzo/client/widget/panel/impl/LienzoPanelPrimitiveDragEventDetailTest.java
+++ b/lienzo-tests/src/test/java/com/ait/lienzo/client/widget/panel/impl/LienzoPanelPrimitiveDragEventDetailTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ait.lienzo.client.widget.panel.impl;
+
+import com.ait.lienzo.client.core.shape.IPrimitive;
+import com.ait.lienzo.client.widget.panel.LienzoPanel;
+import elemental2.dom.CustomEvent;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+
+public class LienzoPanelPrimitiveDragEventDetailTest {
+
+    private final double DRAG_X = 1.0;
+    private final double DRAG_Y = 2.0;
+    private final String CUSTOM_EVENT_TYPE = "LIENZO EVENT TYPE";
+
+    @Mock
+    private LienzoPanel<? extends LienzoPanel> lienzoPanel;
+
+    @Mock
+    private IPrimitive<?> primitive;
+
+    private LienzoPanelPrimitiveDragEventDetail tested;
+
+    @Before
+    public void setup() {
+        tested = new LienzoPanelPrimitiveDragEventDetail(lienzoPanel,
+                                                         primitive,
+                                                         DRAG_X,
+                                                         DRAG_Y);
+    }
+
+    @Test
+    public void testGetDragDetail() {
+        CustomEvent<?> customEvent = createCustomEvent();
+        assertEquals(tested, LienzoPanelPrimitiveDragEventDetail.getDragDetail(customEvent));
+    }
+
+    @Test
+    public void testGetLienzoPanel() {
+        assertEquals(lienzoPanel, tested.getLienzoPanel());
+    }
+
+    @Test
+    public void testGetPrimitive() {
+        assertEquals(primitive, tested.getPrimitive());
+    }
+
+    @Test
+    public void testGetDragX() {
+        assertEquals(DRAG_X, tested.getDragX(), Double.MIN_NORMAL);
+    }
+
+    @Test
+    public void testGetDragY() {
+        assertEquals(DRAG_Y, tested.getDragY(), Double.MIN_NORMAL);
+    }
+
+    private CustomEvent<?> createCustomEvent() {
+        CustomEvent event = new CustomEvent(CUSTOM_EVENT_TYPE);
+        event.detail = tested;
+        return event;
+    }
+}


### PR DESCRIPTION
The canvas now expands/scrolls automatically anytime a primitive is dragged beyond control limits.

**JIRA**: [KOGITO-6045](https://issues.redhat.com/browse/KOGITO-6045)

**DMN Editor**: [Web App (.war)](https://drive.google.com/file/d/1VgcMBedpD5w6-S4j07e9U1XRO20DsI5w/view?usp=sharing)

**BPMN Editor**: [Web App (.war)](https://drive.google.com/file/d/1q4xiMKpMzjYOu1MTGJZ_sh4gyeVoZqmX/view?usp=sharing)

**VS Code**: [VSCode Extension](https://drive.google.com/file/d/1h4dLGBfL5Og5h8Gqf-SLH4Zn-WWeuGfe/view?usp=sharing)