### PR TITLE
DROOLS-3442: Rename DMN 'Name' to 'DMN Model Name'

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Definitions.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Definitions.java
@@ -18,24 +18,33 @@ package org.kie.workbench.common.dmn.api.definition.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.validation.Valid;
+
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.property.DMNPropertySet;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.api.property.dmn.NameFieldType;
+import org.kie.workbench.common.dmn.api.property.dmn.NameHolder;
 import org.kie.workbench.common.dmn.api.property.dmn.Text;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
+import org.kie.workbench.common.forms.adf.definitions.annotations.i18n.I18nSettings;
 import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
 import org.kie.workbench.common.stunner.core.definition.annotation.Property;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 @Portable
 @Bindable
-@FormDefinition(policy = FieldPolicy.ONLY_MARKED, startElement = "id")
-public class Definitions extends NamedElement implements DMNPropertySet {
+@FormDefinition(policy = FieldPolicy.ONLY_MARKED,
+        i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.model.Definitions"),
+        startElement = "id")
+public class Definitions extends DMNElement implements DMNPropertySet,
+                                                       HasName {
 
     public static final String DEFAULT_EXPRESSION_LANGUAGE = Namespace.FEEL.getUri();
 
@@ -48,6 +57,11 @@ public class Definitions extends NamedElement implements DMNPropertySet {
     private List<ElementCollection> elementCollection;
     private List<BusinessContextElement> businessContextElement;
     private List<DMNDiagramElement> dmnDiagramElements;
+
+    @Property
+    @FormField(afterElement = "description", labelKey = "nameHolder", type = NameFieldType.class)
+    @Valid
+    protected NameHolder nameHolder;
 
     @Property
     @FormField(afterElement = "nameHolder")
@@ -94,8 +108,8 @@ public class Definitions extends NamedElement implements DMNPropertySet {
                        final String exporter,
                        final String exporterVersion) {
         super(id,
-              description,
-              name);
+              description);
+        this.nameHolder = new NameHolder(name);
         this._import = _import;
         this.itemDefinition = itemDefinition;
         this.drgElement = drgElement;
@@ -112,6 +126,16 @@ public class Definitions extends NamedElement implements DMNPropertySet {
     // -----------------------
     // DMN properties
     // -----------------------
+
+    @Override
+    public Name getName() {
+        return nameHolder.getValue();
+    }
+
+    @Override
+    public void setName(final Name name) {
+        this.nameHolder.setValue(name);
+    }
 
     public List<Import> getImport() {
         if (_import == null) {
@@ -212,6 +236,17 @@ public class Definitions extends NamedElement implements DMNPropertySet {
 
     public void setExporterVersion(final String value) {
         this.exporterVersion = value;
+    }
+
+    // ------------------
+    // Errai Data Binding
+    // ------------------
+    public NameHolder getNameHolder() {
+        return nameHolder;
+    }
+
+    public void setNameHolder(final NameHolder nameHolder) {
+        this.nameHolder = nameHolder;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/NamedElement.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/NamedElement.java
@@ -29,7 +29,7 @@ import org.kie.workbench.common.stunner.core.definition.annotation.Property;
 public abstract class NamedElement extends DMNElement implements HasName {
 
     @Property
-    @FormField(afterElement = "description", type = NameFieldType.class)
+    @FormField(afterElement = "description", type = NameFieldType.class, labelKey = "org.kie.workbench.common.dmn.api.property.dmn.NameHolder.label")
     @Valid
     protected NameHolder nameHolder;
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/NameHolder.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/NameHolder.java
@@ -34,7 +34,7 @@ import org.kie.workbench.common.stunner.core.util.HashUtil;
 @Portable
 @Bindable
 @Property(meta = PropertyMetaTypes.NAME)
-@FieldDefinition(i18nMode = I18nMode.OVERRIDE_I18N_KEY)
+@FieldDefinition(i18nMode = I18nMode.DONT_OVERRIDE)
 public class NameHolder implements DMNProperty {
 
     public static final String DEFAULT_NAME = "";

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/api/resources/i18n/DMNAPIConstants.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/api/resources/i18n/DMNAPIConstants.properties
@@ -1,4 +1,9 @@
 #######################
+# Definitions
+#######################
+org.kie.workbench.common.dmn.api.definition.model.Definitions.nameHolder=DMN Model Name
+
+#######################
 # DefinitionSet
 #######################
 org.kie.workbench.common.dmn.api.DMNDefinitionSet.description=DMN

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/api/resources/i18n/DMNAPIConstants_es.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/api/resources/i18n/DMNAPIConstants_es.properties
@@ -1,4 +1,9 @@
 #######################
+# Definitions
+#######################
+org.kie.workbench.common.dmn.api.definition.model.Definitions.nameHolder=Nombre del modelo DMN
+
+#######################
 # DefinitionSet
 #######################
 org.kie.workbench.common.dmn.api.DMNDefinitionSet.description=DMN

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/api/resources/i18n/DMNAPIConstants_fr.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/api/resources/i18n/DMNAPIConstants_fr.properties
@@ -1,4 +1,9 @@
 #######################
+# Definitions
+#######################
+org.kie.workbench.common.dmn.api.definition.model.Definitions.nameHolder=Nom du modèle DMN 
+
+#######################
 # DefinitionSet
 #######################
 org.kie.workbench.common.dmn.api.DMNDefinitionSet.description=DMN

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/api/resources/i18n/DMNAPIConstants_ja.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/api/resources/i18n/DMNAPIConstants_ja.properties
@@ -1,4 +1,9 @@
 #######################
+# Definitions
+#######################
+org.kie.workbench.common.dmn.api.definition.model.Definitions.nameHolder=DMN モデル名
+
+#######################
 # DefinitionSet
 #######################
 org.kie.workbench.common.dmn.api.DMNDefinitionSet.description=DMN


### PR DESCRIPTION
For more details see:
- https://issues.redhat.com/browse/DROOLS-3442

Now diagram name and node name have different label in forms:

diagram:
![Screenshot from 2021-10-19 16-47-38](https://user-images.githubusercontent.com/8044780/137934747-cefe1d80-7521-4d15-9b16-f91df2202efa.png)


node:
![Screenshot from 2021-10-19 16-40-35](https://user-images.githubusercontent.com/8044780/137934765-fea8b39a-7598-47b6-b260-06acc5c0e8da.png)
