### PR TITLE
KOGITO-6067 : Tasks in BPMN and specifically BR Node do not allow type to be Collection with a generic

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/diagram/AbstractDataTypeCache.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/diagram/AbstractDataTypeCache.java
@@ -74,21 +74,21 @@ public abstract class AbstractDataTypeCache {
             allDataTypes.add(dataObject.getType().getValue().getType());
         } else if (definition instanceof AdHocSubprocess) {
             AdHocSubprocess adhoc = (AdHocSubprocess) definition;
-            allDataTypes.addAll(getDataTypes(adhoc.getProcessData().getProcessVariables().getValue()));
+            allDataTypes.addAll(getDataTypes(adhoc.getProcessData().getProcessVariables().getValue(), false));
         } else if (definition instanceof BPMNDiagramImpl) {
             BPMNDiagramImpl diagram = (BPMNDiagramImpl) definition;
-            allDataTypes.addAll(getDataTypes(diagram.getProcessData().getProcessVariables().getValue()));
+            allDataTypes.addAll(getDataTypes(diagram.getProcessData().getProcessVariables().getValue(), false));
         } else if (definition instanceof EmbeddedSubprocess) {
             EmbeddedSubprocess embeddedSubprocess = (EmbeddedSubprocess) definition;
-            allDataTypes.addAll(getDataTypes(embeddedSubprocess.getProcessData().getProcessVariables().getValue()));
+            allDataTypes.addAll(getDataTypes(embeddedSubprocess.getProcessData().getProcessVariables().getValue(), false));
         } else if (definition instanceof EventSubprocess) {
             EventSubprocess eventSubprocess = (EventSubprocess) definition;
-            allDataTypes.addAll(getDataTypes(eventSubprocess.getProcessData().getProcessVariables().getValue()));
+            allDataTypes.addAll(getDataTypes(eventSubprocess.getProcessData().getProcessVariables().getValue(), false));
         } else if (definition instanceof MultipleInstanceSubprocess) {
             MultipleInstanceSubprocess multipleInstanceSubprocess = (MultipleInstanceSubprocess) definition;
-            allDataTypes.addAll(getDataTypes(multipleInstanceSubprocess.getProcessData().getProcessVariables().getValue()));
-            allDataTypes.addAll(getDataTypes(multipleInstanceSubprocess.getExecutionSet().getMultipleInstanceDataInput().getValue()));
-            allDataTypes.addAll(getDataTypes(multipleInstanceSubprocess.getExecutionSet().getMultipleInstanceDataOutput().getValue()));
+            allDataTypes.addAll(getDataTypes(multipleInstanceSubprocess.getProcessData().getProcessVariables().getValue(), false));
+            allDataTypes.addAll(getDataTypes(multipleInstanceSubprocess.getExecutionSet().getMultipleInstanceDataInput().getValue(), false));
+            allDataTypes.addAll(getDataTypes(multipleInstanceSubprocess.getExecutionSet().getMultipleInstanceDataOutput().getValue(), false));
         } else if (definition instanceof UserTask) {
             UserTask userTask = (UserTask) definition;
             allDataTypes.addAll(processAssignments(userTask.getExecutionSet().getAssignmentsinfo()));
@@ -162,7 +162,7 @@ public abstract class AbstractDataTypeCache {
 
     protected abstract List<String> processAssignments(AssignmentsInfo info);
 
-    protected abstract List<String> getDataTypes(String variables);
+    protected abstract List<String> getDataTypes(String variables, boolean isTwoColonFormat);
 
     private void cacheImports(List<DefaultImport> defaultImports) {
         for (DefaultImport imported : defaultImports) {
@@ -180,11 +180,11 @@ public abstract class AbstractDataTypeCache {
     }
 
     private void cacheProcessVariables(String processVariables) {
-        allDataTypes.addAll(getDataTypes(processVariables));
+        allDataTypes.addAll(getDataTypes(processVariables, false));
     }
 
     private void cacheGlobalVariables(String globalVariables) {
-        allDataTypes.addAll(getDataTypes(globalVariables));
+        allDataTypes.addAll(getDataTypes(globalVariables, true));
     }
 
     public Set<String> getCachedDataTypes() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/diagram/AbstractDataTypeCacheTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/diagram/AbstractDataTypeCacheTest.java
@@ -84,7 +84,7 @@ public class AbstractDataTypeCacheTest {
             }
 
             @Override
-            protected List<String> getDataTypes(String variables) {
+            protected List<String> getDataTypes(String variables, boolean isTwoColonFormat) {
                 return defaultDataTypes;
             }
         };

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/VariablesProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/VariablesProvider.java
@@ -25,6 +25,7 @@ import java.util.stream.StreamSupport;
 
 import javax.inject.Inject;
 
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDefinition;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagram;
 import org.kie.workbench.common.stunner.bpmn.definition.DataObject;
@@ -107,6 +108,7 @@ public class VariablesProvider
 
     private void addPropertyVariableToResult(Collection<Pair<Object, String>> result, String element) {
         if (element.length() > 0) {
+            element = StringUtils.preFilterVariablesTwoSemicolonForGenerics(element);
             List<String> list = Arrays.asList(element.split(","));
             list.forEach(s1 -> {
                 String value = s1.split(":")[0];

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/artifacts/DataObjectTypeWidget.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/artifacts/DataObjectTypeWidget.java
@@ -92,9 +92,10 @@ public class DataObjectTypeWidget extends Composite implements HasValue<DataObje
                               CUSTOM_PROMPT,
                               ENTER_TYPE_PROMPT);
 
-        customDataType.setRegExp(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_REGEXP,
+        customDataType.setRegExp(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_GT_LT_REGEXP,
                                  StunnerFormsClientFieldsConstants.CONSTANTS.Removed_invalid_characters_from_name(),
-                                 StunnerFormsClientFieldsConstants.CONSTANTS.Invalid_character_in_name());
+                                 StunnerFormsClientFieldsConstants.CONSTANTS.Invalid_character_in_name(),
+                                 StunnerFormsClientFieldsConstants.CONSTANTS.Unbalanced_GT_LT_from_name());
 
         ListBoxValues dataTypeListBoxValues = new ListBoxValues(CUSTOM_PROMPT, "Edit ", null);
         doneLoading = false;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/ActivityDataIOEditorWidget.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/ActivityDataIOEditorWidget.java
@@ -122,6 +122,7 @@ public class ActivityDataIOEditorWidget implements ActivityDataIOEditorWidgetVie
         newAssignment.setVariableType(variableType);
         as.add(newAssignment);
         AssignmentListItemWidgetView widget = view.getAssignmentWidget(view.getAssignmentsCount() - 1);
+
         widget.setDataTypes(dataTypeListBoxValues);
         widget.setProcessVariables(processVarListBoxValues);
         widget.setShowExpressions(getShowExpression());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImpl.java
@@ -204,9 +204,10 @@ public class AssignmentListItemWidgetViewImpl extends Composite implements Assig
                 ValueChangeEvent.fire(name, EMPTY_VALUE);
             }
         });
-        customDataType.setRegExp(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_REGEXP,
+        customDataType.setRegExp(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_GT_LT_REGEXP,
                                  StunnerFormsClientFieldsConstants.CONSTANTS.Removed_invalid_characters_from_name(),
-                                 StunnerFormsClientFieldsConstants.CONSTANTS.Invalid_character_in_name());
+                                 StunnerFormsClientFieldsConstants.CONSTANTS.Invalid_character_in_name(),
+                                 StunnerFormsClientFieldsConstants.CONSTANTS.Unbalanced_GT_LT_from_name());
         customDataType.addKeyDownHandler(event -> {
             int iChar = event.getNativeKeyCode();
             if (iChar == ' ') {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentsEditorWidget.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentsEditorWidget.java
@@ -369,6 +369,7 @@ public class AssignmentsEditorWidget extends Composite implements HasValue<Strin
                                                            assignments,
                                                            datatypes,
                                                            disallowedpropertynames);
+
         assignmentData.setVariableCountsString(hasInputVars,
                                                isSingleInputVar,
                                                hasOutputVars,
@@ -426,7 +427,6 @@ public class AssignmentsEditorWidget extends Composite implements HasValue<Strin
 
     protected String formatDataTypes(final List<String> dataTypes) {
 
-        Set<String> set = getSetDataTypes();
         StringBuilder sb = new StringBuilder();
         if (dataTypes != null && !dataTypes.isEmpty()) {
             List<String> formattedDataTypes = new ArrayList<>(dataTypes.size());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/i18n/StunnerFormsClientFieldsConstants.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/i18n/StunnerFormsClientFieldsConstants.java
@@ -89,6 +89,8 @@ public interface StunnerFormsClientFieldsConstants extends Messages {
 
     String Removed_invalid_characters_from_name();
 
+    String Unbalanced_GT_LT_from_name();
+
     String Removed_invalid_characters_from_value();
 
     String A_Data_Input_with_this_name_already_exists();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/AssignmentData.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/AssignmentData.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.i18n.StunnerFormsClientFieldsConstants;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 
 import static org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils.isEmpty;
 import static org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils.nonEmpty;
@@ -160,13 +161,14 @@ public class AssignmentData {
         return getStringForList(inputVariables);
     }
 
-    public void setInputVariables(final String sInputVariables) {
+    public void setInputVariables(String sInputVariables) {
+        sInputVariables = StringUtils.preFilterVariablesTwoSemicolonForGenerics(sInputVariables);
         inputVariables.clear();
         if (sInputVariables != null && !sInputVariables.isEmpty()) {
             String[] inputs = sInputVariables.split(",");
             for (String input : inputs) {
                 if (!input.isEmpty()) {
-                    Variable var = Variable.deserialize(input,
+                    Variable var = Variable.deserialize(StringUtils.postFilterForGenerics(input),
                                                         Variable.VariableType.INPUT,
                                                         dataTypes);
                     if (var != null && var.getName() != null && !var.getName().isEmpty()) {
@@ -185,13 +187,14 @@ public class AssignmentData {
         return getStringForList(outputVariables);
     }
 
-    public void setOutputVariables(final String sOutputVariables) {
+    public void setOutputVariables( String sOutputVariables) {
+        sOutputVariables = StringUtils.preFilterVariablesTwoSemicolonForGenerics(sOutputVariables);
         outputVariables.clear();
         if (sOutputVariables != null && !sOutputVariables.isEmpty()) {
             String[] outputs = sOutputVariables.split(",");
             for (String output : outputs) {
                 if (!output.isEmpty()) {
-                    Variable var = Variable.deserialize(output,
+                    Variable var = Variable.deserialize(StringUtils.postFilterForGenerics(output),
                                                         Variable.VariableType.OUTPUT,
                                                         dataTypes);
                     if (var != null && var.getName() != null && !var.getName().isEmpty()) {
@@ -259,7 +262,9 @@ public class AssignmentData {
         return dataTypes;
     }
 
-    protected void setDataTypes(final String dataTypes) {
+    protected void setDataTypes(String dataTypes) {
+        dataTypes = StringUtils.preFilterVariablesTwoSemicolonForGenerics(dataTypes);
+
         this.dataTypes.clear();
         this.dataTypeDisplayNames.clear();
         mapDisplayNameToDataType.clear();
@@ -287,6 +292,10 @@ public class AssignmentData {
                     } else {
                         dtSimpleType = dtDisplayName;
                     }
+                    dtName = StringUtils.postFilterForGenerics(dtName);
+                    dtDisplayName = StringUtils.postFilterForGenerics(dtDisplayName);
+                    dtSimpleType = StringUtils.postFilterForGenerics(dtSimpleType);
+
                     if (!dtName.isEmpty()) {
                         this.dataTypeDisplayNames.add(dtDisplayName);
                         this.dataTypes.add(dtName);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/multipleInstanceVariableEditor/MultipleInstanceVariableEditorView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/multipleInstanceVariableEditor/MultipleInstanceVariableEditorView.java
@@ -101,9 +101,10 @@ public class MultipleInstanceVariableEditorView
                               CUSTOM_PROMPT,
                               ENTER_TYPE_PROMPT);
 
-        customDataType.setRegExp(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_REGEXP,
+        customDataType.setRegExp(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_GT_LT_REGEXP,
                                  StunnerFormsClientFieldsConstants.CONSTANTS.Removed_invalid_characters_from_name(),
-                                 StunnerFormsClientFieldsConstants.CONSTANTS.Invalid_character_in_name());
+                                 StunnerFormsClientFieldsConstants.CONSTANTS.Invalid_character_in_name(),
+                                 StunnerFormsClientFieldsConstants.CONSTANTS.Unbalanced_GT_LT_from_name());
 
         ListBoxValues dataTypeListBoxValues = new ListBoxValues(VariableListItemWidgetView.CUSTOM_PROMPT, "Edit ", null);
         clientDataTypesService

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
@@ -284,9 +284,10 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
                               true,
                               CUSTOM_PROMPT,
                               ENTER_TYPE_PROMPT);
-        customDataType.setRegExp(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_REGEXP,
+        customDataType.setRegExp(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_GT_LT_REGEXP,
                                  StunnerFormsClientFieldsConstants.CONSTANTS.Removed_invalid_characters_from_name(),
-                                 StunnerFormsClientFieldsConstants.CONSTANTS.Invalid_character_in_name());
+                                 StunnerFormsClientFieldsConstants.CONSTANTS.Invalid_character_in_name(),
+                                 StunnerFormsClientFieldsConstants.CONSTANTS.Unbalanced_GT_LT_from_name());
         customDataType.addKeyDownHandler(this::preventSpaces);
 
         PopOver.jQuery(variableTagsSettings).popovers();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRenderer.java
@@ -136,6 +136,7 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
                                                                                    dataTypeDisplayNames);
         this.mapDataTypeDisplayNamesToNames = createMapDataTypeDisplayNamesToNames(dataTypes,
                                                                                    dataTypeDisplayNames);
+
         dataTypeListBoxValues = new ListBoxValues(VariableListItemWidgetView.CUSTOM_PROMPT,
                                                   "Edit" + " ",
                                                   dataTypesTester());
@@ -169,13 +170,22 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
         doSave();
     }
 
+
+
+
     @Override
-    public List<VariableRow> deserializeVariables(final String s) {
+    public List<VariableRow> deserializeVariables(String s) {
+        if (isGlobalVariables()) {
+            s = StringUtils.preFilterVariablesTwoSemicolonForGenerics(s);
+        } else {
+            s = StringUtils.preFilterVariablesForGenerics(s);
+        }
         List<VariableRow> variableRows = new ArrayList<>();
         if (s != null && !s.isEmpty()) {
             String[] vs = s.split(",");
             for (String v : vs) {
                 if (!v.isEmpty()) {
+                    v = StringUtils.postFilterForGenerics(v);
                     Variable var = Variable.deserialize(v,
                                                         Variable.VariableType.PROCESS,
                                                         dataTypes);
@@ -276,9 +286,13 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
     }
 
     private void checkTagsNotEnabled() {
-        if (this.field != null && !this.field.getId().equals("processVariables")) {
+        if (isGlobalVariables()) {
             this.view.setTagsNotEnabled();
         }
+    }
+
+    private boolean isGlobalVariables() {
+        return this.field != null && !this.field.getId().equals("processVariables");
     }
 
     public void setLastOverlayOpened(final Button overlayCloseButton) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValues.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValues.java
@@ -169,7 +169,9 @@ public class ListBoxValues {
             if (currentEditValuePrompt != null) {
                 acceptableValuesWithCustomValues.remove(currentEditValuePrompt);
             }
+
             int editPromptIndex = acceptableValuesWithCustomValues.indexOf(currentValue);
+
             if (editPromptIndex > -1) {
                 editPromptIndex++;
             } else if (acceptableValuesWithCustomValues.size() > 1) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtils.java
@@ -35,6 +35,12 @@ public class StringUtils {
     public static final String ALPHA_NUM_UNDERSCORE_DOT_GT_LT_REGEXP = "^[a-zA-Z0-9<>,\\_\\.]*$";
     public static final String ALPHA_NUM_SPACE_REGEXP = "^[a-zA-Z0-9\\-\\_\\ ]*$";
     public static final RegExp EXPRESSION = RegExp.compile(Patterns.EXPRESSION);
+    public static final String REPEATING_DOTS_MSG = "Repeating .";
+    public static final String REPEATING_DOTS = "..";
+    public static final String EMPTY_GENERICS_MSG = "Empty Generics <>";
+    public static final String EMPTY_GENERICS = "<>";
+    public static final String MALFORMED_GENERICS_MSG = "Malformed Generics ><";
+    public static final String MALFORMED_GENERICS = "><";
 
     private static URL url = new URL();
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtils.java
@@ -16,10 +16,12 @@
 
 package org.kie.workbench.common.stunner.bpmn.client.forms.util;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.Stack;
 
 import com.google.gwt.regexp.shared.RegExp;
 import org.kie.workbench.common.stunner.core.util.Patterns;
@@ -30,7 +32,7 @@ import org.kie.workbench.common.stunner.core.util.Patterns;
 public class StringUtils {
 
     public static final String ALPHA_NUM_REGEXP = "^[a-zA-Z0-9\\-\\_]*$";
-    public static final String ALPHA_NUM_UNDERSCORE_DOT_REGEXP = "^[a-zA-Z0-9\\_\\.]*$";
+    public static final String ALPHA_NUM_UNDERSCORE_DOT_GT_LT_REGEXP = "^[a-zA-Z0-9<>,\\_\\.]*$";
     public static final String ALPHA_NUM_SPACE_REGEXP = "^[a-zA-Z0-9\\-\\_\\ ]*$";
     public static final RegExp EXPRESSION = RegExp.compile(Patterns.EXPRESSION);
 
@@ -155,6 +157,12 @@ public class StringUtils {
      */
     public static String createDataTypeDisplayName(String dataType) {
         int i = dataType.lastIndexOf('.');
+        int genericsIndexLT = dataType.lastIndexOf('<');
+        int genericsIndexGT = dataType.lastIndexOf('>');
+
+        if (genericsIndexLT != -1 || genericsIndexGT != -1) {
+            return dataType;
+        }
         StringBuilder formattedDataType = new StringBuilder();
         formattedDataType.append(dataType.substring(i + 1));
         if (i != -1) {
@@ -169,6 +177,7 @@ public class StringUtils {
      * @return
      */
     public static Set<String> getSetDataTypes(String value) {
+        value = preFilterVariablesForGenerics(value);
         Set<String> types = new HashSet<>();
         if (value == null) {
             return types;
@@ -176,7 +185,7 @@ public class StringUtils {
         final String[] split = value.split(",");
         for (String string : split) {
             String type = string.substring(string.indexOf(':') + 1, string.lastIndexOf(':'));
-            types.add(type);
+            types.add(postFilterForGenerics(type));
         }
 
         return types;
@@ -189,5 +198,160 @@ public class StringUtils {
      */
     public static void setURL(URL u) {
         url = u;
+    }
+
+    /**
+     * returns if a string is balanced for generics if it contains generics characters.
+     * ie
+     * List<String>             -> true
+     * Map<String,String>       -> true
+     * List<>                   -> false empty
+     * List<String><String>     -> false
+     * @param string
+     * @return
+     */
+    public static boolean isOkWithGenericsFormat(String string) {
+        Stack<Integer> stack = new Stack<>();
+        List<List<Integer>> ranges = new ArrayList<>();
+        int maximumLength = 0;
+        int maximumIndex = 0;
+        for (int i = 0; i < string.length(); i++) {
+            char c = string.charAt(i);
+            if (c == '<') {
+                stack.push(i);
+            } else if (c == '>') {
+                if (stack.size() != 0) {
+                    final Integer peek = stack.peek();
+                    List<Integer> range = new ArrayList<>();
+                    range.add(peek);
+                    range.add(i);
+                    ranges.add(range);
+                    stack.pop();
+                    int length = (i + 1) - peek;
+                    if (length == 2) { // Empty <>
+                        return false;
+                    }
+                    if (length > maximumLength) {
+                        maximumLength = length;
+                        maximumIndex = ranges.size() - 1;
+                    }
+                } else {
+                    return false;
+                }
+            }
+        }
+
+        if (ranges.size() != 0) {
+
+            List<Integer> maximumString = ranges.get(maximumIndex);
+            int maximumBegin = maximumString.get(0);
+            int maximumEnd = maximumString.get(1);
+
+            for (int i = 0; i < ranges.size(); i++) {
+                if (i == maximumIndex) {
+                    continue;
+                }
+                List<Integer> range = ranges.get(i);
+                int begin = range.get(0);
+                int end = range.get(1) + 1;
+
+                if ((begin < maximumBegin || end < maximumBegin)        // Left
+                        || (begin > maximumEnd || end > maximumEnd)) {  // Right
+                    return false;
+                }
+            }
+        }
+        return stack.size() == 0;
+    }
+
+    /**
+     * prefilters a string to be formated for generics .*
+     * @param string
+     * @return
+     */
+    public static String preFilterVariablesForGenerics(String string) {
+
+        if (string != null && !string.isEmpty()) {
+            int index = 0;
+            boolean done = false;
+            do {
+                int nameIndex = string.indexOf(":", index);
+                String name = string.substring(index, nameIndex);
+
+                int typeIndex = string.indexOf(":", nameIndex + 1);
+
+                if (typeIndex == -1) {
+                    typeIndex = string.length();
+                    done = true;
+                }
+                String type = string.substring(nameIndex + 1, typeIndex).replace(",", "*");
+                string = string.substring(0, nameIndex + 1) + type + string.substring(typeIndex);
+
+                int tagsIndex = string.indexOf(":", typeIndex + 1);
+                if (tagsIndex != -1) {
+                    tagsIndex = string.indexOf(",", typeIndex + 1);
+                    String tags = string.substring(typeIndex + 1, tagsIndex);
+                }
+                index = tagsIndex + 1;
+                if (tagsIndex == -1) {
+                    done = true;
+                }
+            } while (!done);
+        }
+        return string;
+    }
+
+    /**
+     * prefilters a string to be formated for generics .*
+     * @param string
+     * @return
+     */
+    public static String preFilterVariablesTwoSemicolonForGenerics(String string) {
+
+        if (string != null) {
+            Stack<Integer> stack = new Stack<>();
+            List<List<Integer>> ranges = new ArrayList<>();
+            for (int i = 0; i < string.length(); i++) {
+                char c = string.charAt(i);
+                if (c == '<') {
+                    stack.push(i);
+                } else if (c == '>') {
+                    if (stack.size() != 0) {
+                        final Integer peek = stack.peek();
+                        List<Integer> range = new ArrayList<>();
+                        range.add(peek);
+                        range.add(i);
+                        ranges.add(range);
+                        stack.pop();
+                    }
+                }
+            }
+
+            if (ranges.size() == 0) { // No Generics
+                return string;
+            }
+
+            for (int i = 0; i < ranges.size(); i++) {
+                List<Integer> range = ranges.get(i);
+                int begin = range.get(0);
+                int end = range.get(1) + 1;
+                String theString = string.substring(begin, end).replace(",", "*");
+                string = string.substring(0, begin) + theString + string.substring(end);
+            }
+        }
+        return string;
+    }
+
+    /**
+     * prefilters a string to be formated for generics .*
+     * @param string
+     * @return
+     */
+    public static String postFilterForGenerics(String string) {
+        if (string != null && string.contains("*")) {
+            string = string.replace("*", ",");
+        }
+
+        return string;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/AbstractValidatingTextBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/AbstractValidatingTextBox.java
@@ -33,6 +33,8 @@ public abstract class AbstractValidatingTextBox extends TextBox {
     @Inject
     private Event<NotificationEvent> notification;
 
+    private static int lastKey = 0;
+
     public AbstractValidatingTextBox() {
         super();
         setup();
@@ -46,18 +48,20 @@ public abstract class AbstractValidatingTextBox extends TextBox {
             public void onKeyPress(final KeyPressEvent event) {
                 // Permit navigation
                 int keyCode = getKeyCodeFromKeyPressEvent(event);
+                boolean repeatingDots = (keyCode == KeyCodes.KEY_DELETE && lastKey == KeyCodes.KEY_DELETE);
+                lastKey = keyCode;
                 if (event.isControlKeyDown()) {
                     return;
                 }
                 if (!event.isShiftKeyDown()) {
-                    if (keyCode == KeyCodes.KEY_BACKSPACE
+                    if ((keyCode == KeyCodes.KEY_BACKSPACE
                             || keyCode == KeyCodes.KEY_DELETE
                             || keyCode == KeyCodes.KEY_LEFT
                             || keyCode == KeyCodes.KEY_RIGHT
                             || keyCode == KeyCodes.KEY_ENTER
                             || keyCode == KeyCodes.KEY_TAB
                             || keyCode == KeyCodes.KEY_HOME
-                            || keyCode == KeyCodes.KEY_END) {
+                            || keyCode == KeyCodes.KEY_END) && !repeatingDots) {
                         return;
                     }
                 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/AbstractValidatingTextBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/AbstractValidatingTextBox.java
@@ -85,15 +85,31 @@ public abstract class AbstractValidatingTextBox extends TextBox {
                 String validationError = isValidValue(value,
                                                       true);
                 if (validationError != null) {
-                    fireValidationError(validationError);
-                    String validValue = makeValidValue(value);
-                    me.setValue(validValue);
-                    ValueChangeEvent.fire(AbstractValidatingTextBox.this,
-                                          validValue);
+                    fireValidation(value, validationError, me);
+                } else {
+                   validationError = isBalancedGTLT(value);
+                    if (validationError != null) {
+                        fireValidation(value, validationError, me);
+                    }
                 }
             }
         });
     }
+
+    private void fireValidation(String value, String validationError, TextBox me) {
+        fireValidationError(validationError);
+        String validValue = makeValidValue(value);
+        me.setValue(validValue);
+        ValueChangeEvent.fire(AbstractValidatingTextBox.this,
+                              validValue);
+    }
+
+    /**
+     * Tests whether a string has balanced <> hence indicating if it looks like valid generics format
+     * @param string
+     * @return an error message to be reported
+     */
+    public abstract String isBalancedGTLT(String string);
 
     /**
      * Tests whether a value is valid

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/AttributeValueTextBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/AttributeValueTextBox.java
@@ -94,6 +94,11 @@ public class AttributeValueTextBox extends AbstractValidatingTextBox {
     }
 
     @Override
+    public String isBalancedGTLT(String string) {
+        return null;
+    }
+
+    @Override
     protected String makeValidValue(final String value) {
         if (value == null || value.isEmpty()) {
             return "";

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/CustomDataTypeTextBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/CustomDataTypeTextBox.java
@@ -45,8 +45,22 @@ public class CustomDataTypeTextBox extends AbstractValidatingTextBox {
                                final boolean isOnFocusLost) {
         if (regExp != null) {
             boolean isValid = this.regExp.test(value);
-            if (!isValid) {
+            boolean repeatingDots = value.contains(StringUtils.REPEATING_DOTS);
+            boolean emptyGenerics = value.contains(StringUtils.EMPTY_GENERICS);
+            boolean malformedGenerics = value.contains(StringUtils.MALFORMED_GENERICS);
+            if (!isValid || repeatingDots || emptyGenerics || malformedGenerics) {
                 String invalidChars = getInvalidCharsInName(regExp, value);
+                if (repeatingDots) {
+                    invalidChars = StringUtils.REPEATING_DOTS_MSG;
+                }
+
+                if (emptyGenerics) {
+                    invalidChars = StringUtils.EMPTY_GENERICS_MSG;
+                }
+
+                if (malformedGenerics) {
+                    invalidChars = StringUtils.MALFORMED_GENERICS_MSG;
+                }
                 return (isOnFocusLost ? invalidCharactersInNameErrorMessage : invalidCharacterTypedMessage)
                         + ": " + invalidChars;
             }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/CustomDataTypeTextBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/CustomDataTypeTextBox.java
@@ -17,12 +17,14 @@
 package org.kie.workbench.common.stunner.bpmn.client.forms.widgets;
 
 import com.google.gwt.regexp.shared.RegExp;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 
 public class CustomDataTypeTextBox extends AbstractValidatingTextBox {
 
     private RegExp regExp;
     private String invalidCharacterTypedMessage;
     private String invalidCharactersInNameErrorMessage;
+    private String unbalancedGTLTMessage;
 
     public CustomDataTypeTextBox() {
         this.regExp = null;
@@ -30,10 +32,12 @@ public class CustomDataTypeTextBox extends AbstractValidatingTextBox {
 
     public void setRegExp(final String pattern,
                           final String invalidCharactersInNameErrorMessage,
-                          final String invalidCharacterTypedMessage) {
+                          final String invalidCharacterTypedMessage,
+                          final String unbalancedGTLTMessage) {
         regExp = RegExp.compile(pattern);
         this.invalidCharactersInNameErrorMessage = invalidCharactersInNameErrorMessage;
         this.invalidCharacterTypedMessage = invalidCharacterTypedMessage;
+        this.unbalancedGTLTMessage = unbalancedGTLTMessage;
     }
 
     @Override
@@ -46,6 +50,14 @@ public class CustomDataTypeTextBox extends AbstractValidatingTextBox {
                 return (isOnFocusLost ? invalidCharactersInNameErrorMessage : invalidCharacterTypedMessage)
                         + ": " + invalidChars;
             }
+        }
+        return null;
+    }
+
+    @Override
+    public String isBalancedGTLT(String string) {
+        if (!StringUtils.isOkWithGenericsFormat(string)) {
+            return unbalancedGTLTMessage;
         }
         return null;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/VariableNameTextBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/VariableNameTextBox.java
@@ -94,6 +94,11 @@ public class VariableNameTextBox extends AbstractValidatingTextBox {
         return null;
     }
 
+    @Override
+    public String isBalancedGTLT(String string) {
+        return null;
+    }
+
     /**
      * Tests whether a value is in the list of invalid values
      * @param value

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/forms/fields/i18n/StunnerFormsClientFieldsConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/forms/fields/i18n/StunnerFormsClientFieldsConstants.properties
@@ -47,6 +47,7 @@ Target=Target
 assignment_target_help=The output variable target can be a variable or expression.
 This_input_should_be_entered_as_a_property_for_the_task=This Input should be entered as a property for the task
 Removed_invalid_characters_from_name=Removed invalid characters from name
+Unbalanced_GT_LT_from_name=Bad Generics Format (Unbalanced, Empty, or Bad Format)<> from name
 Removed_invalid_characters_from_value=Removed invalid characters from value
 A_Data_Input_with_this_name_already_exists=A Data Input with this name already exists
 ProcessModel=Process Model

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetTest.java
@@ -143,7 +143,7 @@ public class AssignmentListItemWidgetTest {
         widget.init();
         verify(widget,
                times(1)).init();
-        verify(customDataType, times(1)).setRegExp(eq(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_REGEXP), anyString(), anyString());
+        verify(customDataType, times(1)).setRegExp(eq(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_GT_LT_REGEXP), anyString(), anyString(), anyString());
         verify(dataTypeComboBox,
                times(1)).init(widget,
                               false,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImplTest.java
@@ -263,7 +263,7 @@ public class AssignmentListItemWidgetViewImplTest {
     @Test
     public void testDataTypeHandlerSpace() {
         view.init();
-        verify(customDataType, times(1)).setRegExp(eq(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_REGEXP), anyString(), anyString());
+        verify(customDataType, times(1)).setRegExp(eq(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_GT_LT_REGEXP), anyString(), anyString(), anyString());
         verify(customDataType, times(1)).addKeyDownHandler(keyDownHandlerCaptor.capture());
         KeyDownHandler handler = keyDownHandlerCaptor.getValue();
         doReturn((int) ' ').when(keyDownEvent).getNativeKeyCode();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetTest.java
@@ -179,12 +179,13 @@ public class VariableListItemWidgetTest {
         verify(customDataType,
                times(1)).setRegExp(customValueRegExpCaptor.capture(),
                                    anyString(),
+                                   anyString(),
                                    anyString());
         RegExp customValueRegExp = RegExp.compile(customValueRegExpCaptor.getValue());
         assertEquals(false, customValueRegExp.test("a 1"));
-        assertEquals(false, customValueRegExp.test("<a1"));
-        assertEquals(false, customValueRegExp.test("a1>"));
-        assertEquals(false, customValueRegExp.test("<a1>"));
+        assertEquals(true, customValueRegExp.test("<a1"));
+        assertEquals(true, customValueRegExp.test("a1>"));
+        assertEquals(true, customValueRegExp.test("<a1>"));
         assertEquals(false, customValueRegExp.test("<a1/>"));
         assertEquals(false, customValueRegExp.test("<a1\\>"));
         assertEquals(false, customValueRegExp.test("a@1"));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtilsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtilsTest.java
@@ -65,6 +65,13 @@ public class StringUtilsTest {
     }
 
     @Test
+    public void testCreateDataTypeDisplayNameWithGenerics() {
+        //if < > in string, it should not apply FQDN
+        assertEquals("java.util.Map<java.util.List<String>, String>",
+                     StringUtils.createDataTypeDisplayName("java.util.Map<java.util.List<String>, String>"));
+    }
+
+    @Test
     public void testRegexSequence() {
 
         String test1 = "123Test";
@@ -219,4 +226,84 @@ public class StringUtilsTest {
         setDataTypes = StringUtils.getSetDataTypes(null);
         assertTrue("Data Types must be empty", setDataTypes.size() == 0);
     }
+
+    @Test
+    public void testIsGenericsFormatOk() {
+        //ok
+        assertTrue("Should be ok generics format", StringUtils.isOkWithGenericsFormat("String"));
+        assertTrue("Should be ok generics format", StringUtils.isOkWithGenericsFormat("List"));
+    }
+
+    @Test
+    public void testIsGenericsFormatCorrectMap() {
+        assertTrue("Should be ok generics format", StringUtils.isOkWithGenericsFormat("Map<String,String>"));
+    }
+
+    @Test
+    public void testIsGenericsFormatInCorrectMap() {
+        assertFalse("Should NOT be ok generics format", StringUtils.isOkWithGenericsFormat("Map<String><String>"));
+    }
+
+    @Test
+    public void testIsGenericsFormatUnbalanced() {
+        assertFalse("Should NOT be ok generics format", StringUtils.isOkWithGenericsFormat("Map<String, String"));
+    }
+
+    @Test
+    public void testIsGenericsFormatCorrectList() {
+        assertTrue("Should be ok generics format", StringUtils.isOkWithGenericsFormat("List<String>"));
+    }
+
+    @Test
+    public void testIsGenericsFormatInCorrectList() {
+        assertFalse("Should NOT be ok generics format", StringUtils.isOkWithGenericsFormat("List<List<String>"));
+    }
+
+
+    @Test
+    public void testIsGenericsFormatCorrectSet() {
+        assertTrue("Should be ok generics format", StringUtils.isOkWithGenericsFormat("Set<String>"));
+    }
+
+    @Test
+    public void testIsGenericsFormatInCorrectSet() {
+        assertFalse("Should NOT be ok generics format", StringUtils.isOkWithGenericsFormat("Set<Set<String>"));
+    }
+
+    @Test
+    public void testIsGenericsFormatCorrectStack() {
+        assertTrue("Should be ok generics format", StringUtils.isOkWithGenericsFormat("Stack<String>"));
+    }
+
+    @Test
+    public void testIsGenericsFormatInCorrectStack() {
+        assertFalse("Should NOT be ok generics format", StringUtils.isOkWithGenericsFormat("Stack<Stack<String>"));
+    }
+
+
+
+        @Test
+    public void testPreFilterVariablesForGenerics() {
+        assertEquals("Bad Formad", "map:Map<String*String>:", StringUtils.preFilterVariablesForGenerics("map:Map<String,String>:"));
+        assertEquals("Bad Formad", "list:List<String>:", StringUtils.preFilterVariablesForGenerics("list:List<String>:"));
+        assertEquals("Should be null", null, StringUtils.preFilterVariablesForGenerics(null));
+        assertEquals("Should be empy", "", StringUtils.preFilterVariablesForGenerics(""));
+    }
+
+    @Test
+    public void testPreFilterVariablesTwoSemicolonForGenerics() {
+        assertEquals("Bad Formad", "map:Map<String*String>", StringUtils.preFilterVariablesTwoSemicolonForGenerics("map:Map<String,String>"));
+        assertEquals("Bad Formad", "list:List<String>", StringUtils.preFilterVariablesTwoSemicolonForGenerics("list:List<String>"));
+        assertEquals("Should be null", null, StringUtils.preFilterVariablesTwoSemicolonForGenerics(null));
+        assertEquals("Should be empy", "", StringUtils.preFilterVariablesTwoSemicolonForGenerics(""));
+    }
+
+    @Test
+    public void testPostFilterForGenerics() {
+        assertEquals("Bad Formad", "map:Map<String,String>", StringUtils.postFilterForGenerics("map:Map<String*String>"));
+        assertEquals("Bad Formad", "list:List<Map<String,String>>", StringUtils.postFilterForGenerics("list:List<Map<String*String>>"));
+        assertEquals("Should be null", null, StringUtils.postFilterForGenerics(null));
+        assertEquals("Should be empy", "", StringUtils.postFilterForGenerics(""));
+    }
+
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/CustomDataTypeTextBoxTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/CustomDataTypeTextBoxTest.java
@@ -44,6 +44,7 @@ public class CustomDataTypeTextBoxTest {
 
     private static final String ERROR_REMOVED = "some error reg exp";
     private static final String ERROR_TYPED = "some error reg exp2";
+    private static final String ERROR_UNBALANCED = "some error reg exp3";
 
     @Captor
     private ArgumentCaptor<BlurHandler> blurCaptor;
@@ -65,6 +66,7 @@ public class CustomDataTypeTextBoxTest {
         textBox = GWT.create(CustomDataTypeTextBox.class);
         doCallRealMethod().when(textBox).setRegExp(anyString(),
                                                    anyString(),
+                                                   anyString(),
                                                    anyString());
         doCallRealMethod().when(textBox).isValidValue(anyString(),
                                                       anyBoolean());
@@ -75,9 +77,12 @@ public class CustomDataTypeTextBoxTest {
         doCallRealMethod().when(textBox).setup();
         doCallRealMethod().when(textBox).addBlurHandler(any(BlurHandler.class));
         doCallRealMethod().when(textBox).addKeyPressHandler(any(KeyPressHandler.class));
-        textBox.setRegExp(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_REGEXP,
+        doCallRealMethod().when(textBox).isBalancedGTLT(anyString());
+
+        textBox.setRegExp(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_GT_LT_REGEXP,
                           ERROR_REMOVED,
-                          ERROR_TYPED);
+                          ERROR_TYPED,
+                          ERROR_UNBALANCED);
     }
 
     @Test
@@ -133,7 +138,7 @@ public class CustomDataTypeTextBoxTest {
         assertEquals("ab21",
                      makeValidResult);
         makeValidResult = textBox.makeValidValue("<a#b$2%1.3-4_5>");
-        assertEquals("ab21.34_5",
+        assertEquals("<ab21.34_5>",
                      makeValidResult);
     }
 
@@ -182,7 +187,27 @@ public class CustomDataTypeTextBoxTest {
                      isValidResult);
         isValidResult = textBox.isValidValue("<a#$%1>",
                                              false);
-        assertEquals(ERROR_TYPED + ": <#$%>",
+        assertEquals(ERROR_TYPED + ": #$%",
+                     isValidResult);
+    }
+
+    @Test
+    public void testIsBalancedGTLT() {
+        String isValidResult;
+        isValidResult = textBox.isBalancedGTLT("List<String>");
+        assertEquals(null,
+                     isValidResult);
+        isValidResult = textBox.isBalancedGTLT("List<String");
+        assertEquals(ERROR_UNBALANCED,
+                     isValidResult);
+        isValidResult = textBox.isBalancedGTLT("ListString>");
+        assertEquals(ERROR_UNBALANCED,
+                     isValidResult);
+        isValidResult = textBox.isBalancedGTLT("List<List<String>>");
+        assertEquals(null,
+                     isValidResult);
+        isValidResult = textBox.isBalancedGTLT("List<List<String>");
+        assertEquals(ERROR_UNBALANCED,
                      isValidResult);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/services/DataTypeNamesStandaloneService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/services/DataTypeNamesStandaloneService.java
@@ -27,23 +27,22 @@ import javax.inject.Inject;
 
 import elemental2.promise.Promise;
 import org.kie.workbench.common.stunner.bpmn.client.forms.DataTypeNamesService;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.tostunner.processes.DataTypeCache;
 import org.uberfire.backend.vfs.Path;
 
 @ApplicationScoped
 public class DataTypeNamesStandaloneService implements DataTypeNamesService {
 
+    private static Set<String> simpleDataTypes = new HashSet<>(Arrays.asList("Boolean",
+                                                                             "Float",
+                                                                             "Integer",
+                                                                             "Object",
+                                                                             "String"));
     Set<String> dataTypesSet = new HashSet<>();
-
     boolean cacheRead = false;
     @Inject
     DataTypeCache cache;
-
-    private static Set<String> simpleDataTypes = new HashSet<>(Arrays.asList("Boolean",
-                                                                      "Float",
-                                                                      "Integer",
-                                                                      "Object",
-                                                                      "String"));
 
     @Override
     public Promise<List<String>> call(final Path path) {
@@ -52,13 +51,11 @@ public class DataTypeNamesStandaloneService implements DataTypeNamesService {
             dataTypesSet.addAll(cache.getCachedDataTypes());
             cacheRead = true;
         }
-
         return Promise.resolve(new ArrayList<>(dataTypesSet));
     }
 
     @Override
     public void add(String value, String oldValue) {
-
         if (simpleDataTypes.contains(value)) {
             return;
         }
@@ -67,6 +64,8 @@ public class DataTypeNamesStandaloneService implements DataTypeNamesService {
             dataTypesSet.remove(oldValue);
         }
 
-        dataTypesSet.add(value);
+        if (StringUtils.isOkWithGenericsFormat(value)) {
+            dataTypesSet.add(value);
+        }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/elements/GlobalVariablesElement.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/elements/GlobalVariablesElement.java
@@ -29,6 +29,7 @@ import org.eclipse.emf.ecore.impl.EStructuralFeatureImpl;
 import org.eclipse.emf.ecore.util.FeatureMap;
 import org.jboss.drools.DroolsFactory;
 import org.jboss.drools.GlobalType;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 
 import static org.jboss.drools.DroolsPackage.Literals.DOCUMENT_ROOT__GLOBAL;
 
@@ -71,6 +72,7 @@ public class GlobalVariablesElement extends ElementDefinition<String> {
 
     @Override
     protected void setStringValue(BaseElement element, String value) {
+        value = StringUtils.preFilterVariablesTwoSemicolonForGenerics(value);
         Stream.of(value.split(","))
                 .map(GlobalVariablesElement::extensionOf)
                 .forEach(getExtensionElements(element)::add);
@@ -83,6 +85,7 @@ public class GlobalVariablesElement extends ElementDefinition<String> {
     }
 
     static GlobalType globalTypeDataOf(String variable) {
+        variable = StringUtils.postFilterForGenerics(variable);
         GlobalType globalType = DroolsFactory.eINSTANCE.createGlobalType();
         String[] properties = variable.split(":", -1);
         globalType.setIdentifier(properties[0]);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ActivityPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ActivityPropertyWriter.java
@@ -29,6 +29,7 @@ import org.eclipse.bpmn2.DataOutputAssociation;
 import org.eclipse.bpmn2.InputOutputSpecification;
 import org.eclipse.bpmn2.InputSet;
 import org.eclipse.bpmn2.OutputSet;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.InitializedVariable.InitializedInputVariable;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.InitializedVariable.InitializedOutputVariable;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.ParsedAssignmentsInfo;
@@ -66,12 +67,15 @@ public class ActivityPropertyWriter extends PropertyWriter {
     }
 
     public void setAssignmentsInfo(AssignmentsInfo info) {
+        info.setValue(StringUtils.preFilterVariablesTwoSemicolonForGenerics(info.getValue()));
         final ParsedAssignmentsInfo assignmentsInfo = ParsedAssignmentsInfo.of(info);
         final List<InitializedInputVariable> inputs = assignmentsInfo.createInitializedInputVariables(getId(),
                                                                                                       variableScope, dataObjects);
         if (!inputs.isEmpty()) {
             final InputOutputSpecification ioSpec = getIoSpecification();
             for (InitializedInputVariable input : inputs) {
+                input.getItemDefinition().setStructureRef(StringUtils.postFilterForGenerics(input.getType()));
+
                 if (isReservedIdentifier(input.getIdentifier())) {
                     continue;
                 }
@@ -92,6 +96,7 @@ public class ActivityPropertyWriter extends PropertyWriter {
         if (!outputs.isEmpty()) {
             final InputOutputSpecification ioSpec = getIoSpecification();
             for (InitializedOutputVariable output : outputs) {
+                output.getItemDefinition().setStructureRef(StringUtils.postFilterForGenerics(output.getType()));
                 DataOutput dataOutput = output.getDataOutput();
                 getOutputSet(ioSpec).getDataOutputRefs().add(dataOutput);
                 ioSpec.getDataOutputs().add(dataOutput);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ProcessPropertyWriter.java
@@ -42,6 +42,7 @@ import org.eclipse.dd.di.DiagramElement;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.impl.EStructuralFeatureImpl;
 import org.eclipse.emf.ecore.util.FeatureMap;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.CustomAttribute;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.CustomElement;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.DeclarationList;
@@ -191,12 +192,13 @@ public class ProcessPropertyWriter extends BasePropertyWriter implements Element
 
     public void setProcessVariables(BaseProcessVariables processVariables) {
         String value = processVariables.getValue();
+        value = StringUtils.preFilterVariablesForGenerics(value);
         DeclarationList declarationList = DeclarationList.fromString(value);
 
         List<Property> properties = process.getProperties();
         declarationList.getDeclarations().forEach(decl -> {
             VariableScope.Variable variable =
-                    variableScope.declare(this.process.getId(), decl.getIdentifier(), decl.getType(), decl.getTags());
+                    variableScope.declare(this.process.getId(), decl.getIdentifier(), StringUtils.postFilterForGenerics(decl.getType()), decl.getTags());
             if (!decl.getTags().isEmpty()) {
                 CustomElement.customTags.of(variable.getTypedIdentifier()).set(decl.getTags());
             }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/SubProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/SubProcessPropertyWriter.java
@@ -29,6 +29,7 @@ import org.eclipse.bpmn2.LaneSet;
 import org.eclipse.bpmn2.Property;
 import org.eclipse.bpmn2.SubProcess;
 import org.eclipse.bpmn2.di.BPMNEdge;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.CustomElement;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.DeclarationList;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.fromstunner.ElementContainer;
@@ -95,12 +96,13 @@ public class SubProcessPropertyWriter extends MultipleInstanceActivityPropertyWr
 
     public void setProcessVariables(BaseProcessVariables processVariables) {
         String value = processVariables.getValue();
+        value = StringUtils.preFilterVariablesForGenerics(value);
         DeclarationList declarationList = DeclarationList.fromString(value);
 
         List<Property> properties = process.getProperties();
         declarationList.getDeclarations().forEach(decl -> {
             VariableScope.Variable variable =
-                    variableScope.declare(this.process.getId(), decl.getIdentifier(), decl.getType());
+                    variableScope.declare(this.process.getId(), decl.getIdentifier(), StringUtils.postFilterForGenerics(decl.getType()));
             if (!decl.getTags().isEmpty()) {
                 CustomElement.customTags.of(variable.getTypedIdentifier()).set(decl.getTags());
             }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/processes/DataTypeCache.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/processes/DataTypeCache.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import javax.inject.Singleton;
 
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.DeclarationList;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.ParsedAssignmentsInfo;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.tostunner.BpmnNode;
@@ -65,10 +66,21 @@ public class DataTypeCache extends AbstractDataTypeCache {
         return dataTypes;
     }
 
-    protected List<String> getDataTypes(String variables) {
+    protected List<String> getDataTypes(String variables, boolean isTwoColonFormat) {
+        if (isTwoColonFormat) {
+            variables = StringUtils.preFilterVariablesTwoSemicolonForGenerics(variables);
+        } else {
+            variables = StringUtils.preFilterVariablesForGenerics(variables);
+        }
+
         List<String> dataTypeList = new ArrayList<>();
         DeclarationList list = DeclarationList.fromString(variables);
-        list.getDeclarations().forEach(var -> dataTypeList.add(var.getType()));
+        list.getDeclarations().forEach(var -> {
+            final String s = StringUtils.postFilterForGenerics(var.getType());
+            if (StringUtils.isOkWithGenericsFormat(s)) {
+                dataTypeList.add(s);
+            }
+        });
         return dataTypeList;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/ProcessVariableReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/ProcessVariableReader.java
@@ -36,11 +36,13 @@ class ProcessVariableReader {
 
     private static String toProcessVariableString(Property p) {
         String processVariableName = getProcessVariableName(p);
+
         String tags = CustomElement.customTags.of(p).get();
-        return Optional.ofNullable(p.getItemSubjectRef())
+        final String s = Optional.ofNullable(p.getItemSubjectRef())
                 .map(ItemDefinition::getStructureRef)
                 .map(type -> processVariableName + ":" + type + ":" + tags)
                 .orElse(processVariableName + "::" + tags);
+        return s;
     }
 
     public static String getProcessVariableName(Property p) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/elements/GlobalVariablesElementTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/elements/GlobalVariablesElementTest.java
@@ -31,7 +31,7 @@ import static org.kie.workbench.common.stunner.bpmn.client.marshall.converters.f
 
 public class GlobalVariablesElementTest {
 
-    private final String GLOBAL_VARIABLES = "GV1:Boolean,GV2:Boolean,GV3:Integer";
+    private final String GLOBAL_VARIABLES = "GV1:Boolean,GV2:Boolean,GV3:Integer,GV4:Map<String,String>";
     private final String NAME = "DefaultImports";
     private final String GLOBAL_VARIABLE = "GV1:Boolean";
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ProcessPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ProcessPropertyWriterTest.java
@@ -177,7 +177,7 @@ public class ProcessPropertyWriterTest {
 
     @Test
     public void processVariablesNoTags() {
-        ProcessVariables processVariables = new ProcessVariables("GV1:Boolean,GV2:Boolean,GV3:Integer");
+        ProcessVariables processVariables = new ProcessVariables("GV1:Boolean:,GV2:Boolean:,GV3:Integer:");
         p.setProcessVariables(processVariables);
 
         final ProcessPropertyReader pp = new ProcessPropertyReader(


### PR DESCRIPTION
Hi @romartin can you check this PR? It included a lot of changes in several places due to the fact that we use commas to separate variables, I have tested it extensively and works fine. The only cases where it can fail is when a user enters malformed genercis, example Map<String,String, one thing that I can also add is if I detect that it is malformed, then not add it to the Data Type service to be used in other places, plus maybe adding some code to handle cases when it is malformed. Let me know