### PR TITLE
KOGITO-6076 : Stunner - memory leak on selection node

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeyboardControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeyboardControl.java
@@ -27,6 +27,8 @@ public interface KeyboardControl<C extends Canvas, S extends ClientSession> exte
 
     KeyboardControl<C, S> addKeyShortcutCallback(final KeyShortcutCallback shortcutCallback);
 
+    void removeKeyShortcutCallback(final KeyShortcutCallback shortcutCallback);
+
     void setKeyEventHandlerEnabled(final boolean enabled);
 
     interface KeyShortcutCallback {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeyEventHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeyEventHandler.java
@@ -22,6 +22,8 @@ public interface KeyEventHandler {
 
     KeyEventHandler addKeyShortcutCallback(final KeyboardControl.KeyShortcutCallback shortcutCallback);
 
+    void removeKeyShortcutCallback(final KeyboardControl.KeyShortcutCallback shortcutCallback);
+
     void clear();
 
     void setEnabled(boolean enabled);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeyboardControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeyboardControlImpl.java
@@ -16,6 +16,9 @@
 
 package org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Default;
 import javax.inject.Inject;
@@ -48,10 +51,21 @@ public class KeyboardControlImpl
         this.keyEventHandler = keyEventHandler;
     }
 
+    private Map<KeyShortcutCallback, SessionKeyShortcutCallback> sessionMap = new HashMap<>();
+
     @Override
     public KeyboardControl<AbstractCanvas, ClientSession> addKeyShortcutCallback(final KeyShortcutCallback shortcutCallback) {
-        this.keyEventHandler.addKeyShortcutCallback(new SessionKeyShortcutCallback(shortcutCallback));
+        final SessionKeyShortcutCallback sessionKeyShortcutCallback = new SessionKeyShortcutCallback(shortcutCallback);
+        sessionMap.put(shortcutCallback, sessionKeyShortcutCallback);
+        this.keyEventHandler.addKeyShortcutCallback(sessionKeyShortcutCallback);
         return this;
+    }
+
+    @Override
+    public void removeKeyShortcutCallback(final KeyShortcutCallback shortcutCallback) {
+        final SessionKeyShortcutCallback sessionKeyShortcutCallback = sessionMap.get(shortcutCallback);
+        this.keyEventHandler.removeKeyShortcutCallback(sessionKeyShortcutCallback);
+        sessionMap.remove(shortcutCallback);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/proxies/ElementProxy.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/proxies/ElementProxy.java
@@ -102,6 +102,9 @@ public class ElementProxy implements ShapeProxy {
 
     @Override
     public void destroy() {
+        ((EditorSession) (sessionManager.getCurrentSession()))
+                .getKeyboardControl().removeKeyShortcutCallback(unselect);
+
         if (null != view) {
             view.destroy();
         }
@@ -115,15 +118,17 @@ public class ElementProxy implements ShapeProxy {
         return commandManager.execute(canvasHandler, command);
     }
 
+    private KeyboardControl.KogitoKeyPress unselect;
+
     void handleCancelKey() {
-        ((EditorSession)(sessionManager.getCurrentSession()))
+        unselect = new KeyboardControl.KogitoKeyPress(
+                new KeyboardEvent.Key[]{KeyboardEvent.Key.ESC},
+                "Unselect",
+                this::destroy
+        );
+        ((EditorSession) (sessionManager.getCurrentSession()))
                 .getKeyboardControl()
-                .addKeyShortcutCallback(
-                        new KeyboardControl.KogitoKeyPress(
-                                new KeyboardEvent.Key[]{KeyboardEvent.Key.ESC},
-                                "Unselect",
-                                this::destroy
-                        ));
+                .addKeyShortcutCallback(unselect);
     }
 
     public Canvas getCanvas() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/proxies/ConnectorProxyTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/proxies/ConnectorProxyTest.java
@@ -23,9 +23,12 @@ import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.DefaultCanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.client.shape.EdgeShape;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
@@ -92,6 +95,12 @@ public class ConnectorProxyTest {
     @Mock
     private SessionManager sessionManager;
 
+    @Mock
+    private EditorSession currentSession;
+
+    @Mock
+    private KeyboardControl<AbstractCanvas, ClientSession> keyboardControl;
+
     private ConnectorProxy tested;
     private ElementProxy proxy;
     private ElementProxyTest.ElementProxyViewMock<EdgeShape> view;
@@ -147,6 +156,8 @@ public class ConnectorProxyTest {
 
     @Test
     public void testDestroy() {
+        when(sessionManager.getCurrentSession()).thenReturn(currentSession);
+        when(currentSession.getKeyboardControl()).thenReturn(keyboardControl);
         tested.init();
         tested.destroy();
         verify(proxy, times(1)).destroy();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/proxies/ElementProxyTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/proxies/ElementProxyTest.java
@@ -24,8 +24,11 @@ import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.DefaultCanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.client.shape.ElementShape;
 import org.kie.workbench.common.stunner.core.client.shape.ShapeState;
 import org.kie.workbench.common.stunner.core.command.Command;
@@ -75,6 +78,12 @@ public class ElementProxyTest {
 
     @Mock
     private SessionManager sessionManager;
+
+    @Mock
+    private EditorSession currentSession;
+
+    @Mock
+    private KeyboardControl<AbstractCanvas, ClientSession> keyboardControl;
 
     private ElementProxy tested;
     private ElementProxyViewMock<ElementShape> view;
@@ -142,6 +151,14 @@ public class ElementProxyTest {
         tested.execute(c);
         verify(commandManager, times(1)).execute(eq(canvasHandler), eq(c));
         verify(commandManager, never()).allow(any(), any());
+    }
+
+    @Test
+    public void testDestroy() {
+        when(sessionManager.getCurrentSession()).thenReturn(currentSession);
+        when(currentSession.getKeyboardControl()).thenReturn(keyboardControl);
+        tested.destroy();
+        verify(keyboardControl, times(1)).removeKeyShortcutCallback(any());
     }
 
     static class ElementProxyViewMock<S extends ElementShape>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/proxies/NodeProxyTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/proxies/NodeProxyTest.java
@@ -27,9 +27,12 @@ import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.DefaultCanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.client.shape.EdgeShape;
 import org.kie.workbench.common.stunner.core.client.shape.NodeShape;
 import org.kie.workbench.common.stunner.core.command.Command;
@@ -119,6 +122,12 @@ public class NodeProxyTest {
 
     @Mock
     private SessionManager sessionManager;
+
+    @Mock
+    private EditorSession currentSession;
+
+    @Mock
+    private KeyboardControl<AbstractCanvas, ClientSession> keyboardControl;
 
     private NodeProxy tested;
     private ElementProxy proxy;
@@ -233,6 +242,8 @@ public class NodeProxyTest {
 
     @Test
     public void testDestroy() {
+        when(sessionManager.getCurrentSession()).thenReturn(currentSession);
+        when(currentSession.getKeyboardControl()).thenReturn(keyboardControl);
         tested.init();
         tested.destroy();
         verify(proxy, times(1)).destroy();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/session/command/impl/KogitoKeyEventHandlerImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/session/command/impl/KogitoKeyEventHandlerImpl.java
@@ -73,7 +73,7 @@ public class KogitoKeyEventHandlerImpl implements KeyEventHandler {
                     kogitoShortcutCallback.getLabel(),
                     target -> runIfEnabled(shortcutCallback::onKeyShortcut),
                     target -> runIfEnabled(() -> shortcutCallback.onKeyUp(null)),
-                    kogitoShortcutCallback.getOpts()), shortcutCallback);
+                    kogitoShortcutCallback.getOpts()),shortcutCallback);
         } else if (shortcutCallback instanceof KogitoKeyPress) {
             registerShortcut(keyboardShortcutsApi.registerKeyPress(
                     asStringCodes(kogitoShortcutCallback.getKeyCombination()),
@@ -119,12 +119,12 @@ public class KogitoKeyEventHandlerImpl implements KeyEventHandler {
     public void removeKeyShortcutCallback(final KeyboardControl.KeyShortcutCallback shortcutCallback) {
         final Integer key = callbackMap.get(shortcutCallback);
 
-        for (Integer registeredKey : registeredShortcutsIds) {
-            if (Objects.equals(key, registeredKey)) {
+        for (Integer registeredKey: registeredShortcutsIds) {
+            if (Objects.equals(registeredKey, key)) {
                 keyboardShortcutsApi.deregister(registeredKey);
             }
         }
-        callbackMap.remove(shortcutCallback);
+       callbackMap.remove(shortcutCallback);
     }
 
     private String asStringCodes(final KeyboardEvent.Key[] keyCombination) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/session/command/impl/KogitoKeyEventHandlerImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/session/command/impl/KogitoKeyEventHandlerImpl.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -119,7 +120,7 @@ public class KogitoKeyEventHandlerImpl implements KeyEventHandler {
         final Integer key = callbackMap.get(shortcutCallback);
 
         for (Integer registeredKey: registeredShortcutsIds) {
-            if (registeredKey == key) {
+            if (Objects.equals(registeredKey, key)) {
                 keyboardShortcutsApi.deregister(registeredKey);
             }
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/session/command/impl/KogitoKeyEventHandlerImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/session/command/impl/KogitoKeyEventHandlerImpl.java
@@ -73,7 +73,7 @@ public class KogitoKeyEventHandlerImpl implements KeyEventHandler {
                     kogitoShortcutCallback.getLabel(),
                     target -> runIfEnabled(shortcutCallback::onKeyShortcut),
                     target -> runIfEnabled(() -> shortcutCallback.onKeyUp(null)),
-                    kogitoShortcutCallback.getOpts()),shortcutCallback);
+                    kogitoShortcutCallback.getOpts()), shortcutCallback);
         } else if (shortcutCallback instanceof KogitoKeyPress) {
             registerShortcut(keyboardShortcutsApi.registerKeyPress(
                     asStringCodes(kogitoShortcutCallback.getKeyCombination()),
@@ -119,12 +119,12 @@ public class KogitoKeyEventHandlerImpl implements KeyEventHandler {
     public void removeKeyShortcutCallback(final KeyboardControl.KeyShortcutCallback shortcutCallback) {
         final Integer key = callbackMap.get(shortcutCallback);
 
-        for (Integer registeredKey: registeredShortcutsIds) {
-            if (Objects.equals(registeredKey, key)) {
+        for (Integer registeredKey : registeredShortcutsIds) {
+            if (Objects.equals(key, registeredKey)) {
                 keyboardShortcutsApi.deregister(registeredKey);
             }
         }
-       callbackMap.remove(shortcutCallback);
+        callbackMap.remove(shortcutCallback);
     }
 
     private String asStringCodes(final KeyboardEvent.Key[] keyCombination) {


### PR DESCRIPTION
Hi @hasys. @romartin. Fixed the main issue, now it deregiters keys, you can see now that the amount of registered handlers does not increase on each select/unselect. Can you review this PR?