### PR TITLE
KOGITO-6188: [DMN Designer] The keyboard shortcuts modal CSS from the DMN Editor is broken

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.html
@@ -18,7 +18,7 @@
     <div class="kie-dmn-return-to-link">
         <i class="fa fa-angle-double-left" aria-hidden="true"></i><a href="#" data-field="returnToLink"></a>
 
-        <div data-field="beta-boxed-expression-toggle" class="kie-beta-boxed-expression-editor" style="display: none">
+        <div data-field="beta-boxed-expression-toggle" class="kie-beta-boxed-expression-editor">
             <span class="beta-dash"></span>
             <span class="beta-badge" data-i18n-key="Beta"></span>
             <span class="stable-badge" data-i18n-key="Stable"></span>

--- a/kogito-editors-js/packages/boxed-expression-component/showcase/src/index.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/showcase/src/index.tsx
@@ -34,6 +34,7 @@ import {
 } from "./lib";
 import { Button, Modal } from "@patternfly/react-core";
 import { CopyIcon, PenIcon } from "@patternfly/react-icons";
+import "./lib/components/BoxedExpressionEditor/base-no-reset-wrapped.css";
 
 export const App: React.FunctionComponent = () => {
   //This definition comes directly from the decision node

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
@@ -28,6 +28,8 @@ import {
 import { ExpressionContainer } from "../ExpressionContainer";
 import { hashfy, ResizerSupervisor } from "../Resizer";
 import { CellSelectionBox } from "../SelectionBox";
+import "@patternfly/react-styles/css/components/Drawer/drawer.css";
+import "./base-no-reset-wrapped.css";
 import "./BoxedExpressionEditor.css";
 
 export interface BoxedExpressionEditorProps {

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/BoxedExpressionEditor/base-no-reset-wrapped.css
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/BoxedExpressionEditor/base-no-reset-wrapped.css
@@ -1,0 +1,969 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+.boxed-expression-editor  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.boxed-expression-editor .pf-t-light {
+  --pf-global--Color--100: var(--pf-global--Color--dark-100);
+  --pf-global--Color--200: var(--pf-global--Color--dark-200);
+  --pf-global--BorderColor--100: var(--pf-global--BorderColor--dark-100);
+  --pf-global--primary-color--100: var(--pf-global--primary-color--dark-100);
+  --pf-global--link--Color: var(--pf-global--link--Color--dark);
+  --pf-global--link--Color--hover: var(--pf-global--link--Color--dark--hover);
+  --pf-global--BackgroundColor--100: var(--pf-global--BackgroundColor--light-100);
+}
+
+.boxed-expression-editor .pf-t-dark {
+  --pf-global--Color--100: var(--pf-global--Color--light-100);
+  --pf-global--Color--200: var(--pf-global--Color--light-200);
+  --pf-global--BorderColor--100: var(--pf-global--BorderColor--light-100);
+  --pf-global--primary-color--100: var(--pf-global--primary-color--light-100);
+  --pf-global--link--Color: var(--pf-global--link--Color--light);
+  --pf-global--link--Color--hover: var(--pf-global--link--Color--light);
+  --pf-global--BackgroundColor--100: var(--pf-global--BackgroundColor--dark-100);
+}
+
+.boxed-expression-editor .pf-t-dark .pf-c-card {
+  --pf-c-card--BackgroundColor: var(--pf-global--BackgroundColor--dark-transparent-200);
+}
+
+.boxed-expression-editor .pf-t-dark .pf-c-button {
+  --pf-c-button--m-primary--Color: var(--pf-global--primary-color--dark-100);
+  --pf-c-button--m-primary--hover--Color: var(--pf-global--primary-color--dark-100);
+  --pf-c-button--m-primary--focus--Color: var(--pf-global--primary-color--dark-100);
+  --pf-c-button--m-primary--active--Color: var(--pf-global--primary-color--dark-100);
+  --pf-c-button--m-primary--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+  --pf-c-button--m-primary--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
+  --pf-c-button--m-primary--focus--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
+  --pf-c-button--m-primary--active--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
+  --pf-c-button--m-secondary--Color: var(--pf-global--Color--light-100);
+  --pf-c-button--m-secondary--hover--Color: var(--pf-global--Color--light-100);
+  --pf-c-button--m-secondary--focus--Color: var(--pf-global--Color--light-100);
+  --pf-c-button--m-secondary--active--Color: var(--pf-global--Color--light-100);
+  --pf-c-button--m-secondary--BorderColor: var(--pf-global--Color--light-100);
+  --pf-c-button--m-secondary--hover--BorderColor: var(--pf-global--Color--light-100);
+  --pf-c-button--m-secondary--focus--BorderColor: var(--pf-global--Color--light-100);
+  --pf-c-button--m-secondary--active--BorderColor: var(--pf-global--Color--light-100);
+}
+
+:root {
+  --pf-global--palette--black-100: #fafafa;
+  --pf-global--palette--black-150: #f5f5f5;
+  --pf-global--palette--black-200: #f0f0f0;
+  --pf-global--palette--black-300: #d2d2d2;
+  --pf-global--palette--black-400: #b8bbbe;
+  --pf-global--palette--black-500: #8a8d90;
+  --pf-global--palette--black-600: #6a6e73;
+  --pf-global--palette--black-700: #4f5255;
+  --pf-global--palette--black-800: #3c3f42;
+  --pf-global--palette--black-850: #212427;
+  --pf-global--palette--black-900: #151515;
+  --pf-global--palette--black-1000: #030303;
+  --pf-global--palette--blue-50: #e7f1fa;
+  --pf-global--palette--blue-100: #bee1f4;
+  --pf-global--palette--blue-200: #73bcf7;
+  --pf-global--palette--blue-300: #2b9af3;
+  --pf-global--palette--blue-400: #06c;
+  --pf-global--palette--blue-500: #004080;
+  --pf-global--palette--blue-600: #002952;
+  --pf-global--palette--blue-700: #001223;
+  --pf-global--palette--cyan-50: #f2f9f9;
+  --pf-global--palette--cyan-100: #a2d9d9;
+  --pf-global--palette--cyan-200: #73c5c5;
+  --pf-global--palette--cyan-300: #009596;
+  --pf-global--palette--cyan-400: #005f60;
+  --pf-global--palette--cyan-500: #003737;
+  --pf-global--palette--cyan-600: #002323;
+  --pf-global--palette--cyan-700: #000f0f;
+  --pf-global--palette--gold-50: #fdf7e7;
+  --pf-global--palette--gold-100: #f9e0a2;
+  --pf-global--palette--gold-200: #f6d173;
+  --pf-global--palette--gold-300: #f4c145;
+  --pf-global--palette--gold-400: #f0ab00;
+  --pf-global--palette--gold-500: #c58c00;
+  --pf-global--palette--gold-600: #795600;
+  --pf-global--palette--gold-700: #3d2c00;
+  --pf-global--palette--green-50: #f3faf2;
+  --pf-global--palette--green-100: #bde5b8;
+  --pf-global--palette--green-200: #95d58e;
+  --pf-global--palette--green-300: #6ec664;
+  --pf-global--palette--green-400: #5ba352;
+  --pf-global--palette--green-500: #3e8635;
+  --pf-global--palette--green-600: #1e4f18;
+  --pf-global--palette--green-700: #0f280d;
+  --pf-global--palette--light-blue-100: #beedf9;
+  --pf-global--palette--light-blue-200: #7cdbf3;
+  --pf-global--palette--light-blue-300: #35caed;
+  --pf-global--palette--light-blue-400: #00b9e4;
+  --pf-global--palette--light-blue-500: #008bad;
+  --pf-global--palette--light-blue-600: #005c73;
+  --pf-global--palette--light-blue-700: #002d39;
+  --pf-global--palette--light-green-100: #e4f5bc;
+  --pf-global--palette--light-green-200: #c8eb79;
+  --pf-global--palette--light-green-300: #ace12e;
+  --pf-global--palette--light-green-400: #92d400;
+  --pf-global--palette--light-green-500: #6ca100;
+  --pf-global--palette--light-green-600: #486b00;
+  --pf-global--palette--light-green-700: #253600;
+  --pf-global--palette--orange-100: #f4b678;
+  --pf-global--palette--orange-200: #ef9234;
+  --pf-global--palette--orange-300: #ec7a08;
+  --pf-global--palette--orange-400: #c46100;
+  --pf-global--palette--orange-500: #8f4700;
+  --pf-global--palette--orange-600: #773d00;
+  --pf-global--palette--orange-700: #3b1f00;
+  --pf-global--palette--purple-50: #f2f0fc;
+  --pf-global--palette--purple-100: #cbc1ff;
+  --pf-global--palette--purple-200: #b2a3ff;
+  --pf-global--palette--purple-300: #a18fff;
+  --pf-global--palette--purple-400: #8476d1;
+  --pf-global--palette--purple-500: #6753ac;
+  --pf-global--palette--purple-600: #40199a;
+  --pf-global--palette--purple-700: #1f0066;
+  --pf-global--palette--red-50: #faeae8;
+  --pf-global--palette--red-100: #c9190b;
+  --pf-global--palette--red-200: #a30000;
+  --pf-global--palette--red-300: #7d1007;
+  --pf-global--palette--red-400: #470000;
+  --pf-global--palette--red-500: #2c0000;
+  --pf-global--palette--white: #fff;
+  --pf-global--BackgroundColor--100: #fff;
+  --pf-global--BackgroundColor--200: #f0f0f0;
+  --pf-global--BackgroundColor--light-100: #fff;
+  --pf-global--BackgroundColor--light-200: #fafafa;
+  --pf-global--BackgroundColor--light-300: #f0f0f0;
+  --pf-global--BackgroundColor--dark-100: #151515;
+  --pf-global--BackgroundColor--dark-200: #3c3f42;
+  --pf-global--BackgroundColor--dark-300: #212427;
+  --pf-global--BackgroundColor--dark-400: #4f5255;
+  --pf-global--BackgroundColor--dark-transparent-100: rgba(3, 3, 3, 0.62);
+  --pf-global--BackgroundColor--dark-transparent-200: rgba(3, 3, 3, 0.32);
+  --pf-global--Color--100: #151515;
+  --pf-global--Color--200: #6a6e73;
+  --pf-global--Color--300: #3c3f42;
+  --pf-global--Color--400: #8a8d90;
+  --pf-global--Color--light-100: #fff;
+  --pf-global--Color--light-200: #f0f0f0;
+  --pf-global--Color--light-300: #d2d2d2;
+  --pf-global--Color--dark-100: #151515;
+  --pf-global--Color--dark-200: #6a6e73;
+  --pf-global--active-color--100: #06c;
+  --pf-global--active-color--200: #bee1f4;
+  --pf-global--active-color--300: #2b9af3;
+  --pf-global--active-color--400: #73bcf7;
+  --pf-global--disabled-color--100: #6a6e73;
+  --pf-global--disabled-color--200: #d2d2d2;
+  --pf-global--disabled-color--300: #f0f0f0;
+  --pf-global--primary-color--100: #06c;
+  --pf-global--primary-color--200: #004080;
+  --pf-global--primary-color--light-100: #73bcf7;
+  --pf-global--primary-color--dark-100: #06c;
+  --pf-global--secondary-color--100: #6a6e73;
+  --pf-global--default-color--100: #73c5c5;
+  --pf-global--default-color--200: #009596;
+  --pf-global--default-color--300: #003737;
+  --pf-global--success-color--100: #3e8635;
+  --pf-global--success-color--200: #1e4f18;
+  --pf-global--info-color--100: #2b9af3;
+  --pf-global--info-color--200: #002952;
+  --pf-global--warning-color--100: #f0ab00;
+  --pf-global--warning-color--200: #795600;
+  --pf-global--danger-color--100: #c9190b;
+  --pf-global--danger-color--200: #a30000;
+  --pf-global--danger-color--300: #470000;
+  --pf-global--BoxShadow--sm: 0 0.0625rem 0.125rem 0 rgba(3, 3, 3, 0.12), 0 0 0.125rem 0 rgba(3, 3, 3, 0.06);
+  --pf-global--BoxShadow--sm-top: 0 -0.125rem 0.25rem -0.0625rem rgba(3, 3, 3, 0.16);
+  --pf-global--BoxShadow--sm-right: 0.125rem 0 0.25rem -0.0625rem rgba(3, 3, 3, 0.16);
+  --pf-global--BoxShadow--sm-bottom: 0 0.125rem 0.25rem -0.0625rem rgba(3, 3, 3, 0.16);
+  --pf-global--BoxShadow--sm-left: -0.125rem 0 0.25rem -0.0625rem rgba(3, 3, 3, 0.16);
+  --pf-global--BoxShadow--md: 0 0.25rem 0.5rem 0rem rgba(3, 3, 3, 0.12), 0 0 0.25rem 0 rgba(3, 3, 3, 0.06);
+  --pf-global--BoxShadow--md-top: 0 -0.5rem 0.5rem -0.375rem rgba(3, 3, 3, 0.18);
+  --pf-global--BoxShadow--md-right: 0.5rem 0 0.5rem -0.375rem rgba(3, 3, 3, 0.18);
+  --pf-global--BoxShadow--md-bottom: 0 0.5rem 0.5rem -0.375rem rgba(3, 3, 3, 0.18);
+  --pf-global--BoxShadow--md-left: -0.5rem 0 0.5rem -0.375rem rgba(3, 3, 3, 0.18);
+  --pf-global--BoxShadow--lg: 0 0.5rem 1rem 0 rgba(3, 3, 3, 0.16), 0 0 0.375rem 0 rgba(3, 3, 3, 0.08);
+  --pf-global--BoxShadow--lg-top: 0 -0.75rem 0.75rem -0.5rem rgba(3, 3, 3, 0.18);
+  --pf-global--BoxShadow--lg-right: 0.75rem 0 0.75rem -0.5rem rgba(3, 3, 3, 0.18);
+  --pf-global--BoxShadow--lg-bottom: 0 0.75rem 0.75rem -0.5rem rgba(3, 3, 3, 0.18);
+  --pf-global--BoxShadow--lg-left: -0.75rem 0 0.75rem -0.5rem rgba(3, 3, 3, 0.18);
+  --pf-global--BoxShadow--xl: 0 1rem 2rem 0 rgba(3, 3, 3, 0.16), 0 0 0.5rem 0 rgba(3, 3, 3, 0.1);
+  --pf-global--BoxShadow--xl-top: 0 -1rem 1rem -0.5rem rgba(3, 3, 3, 0.2);
+  --pf-global--BoxShadow--xl-right: 1rem 0 1rem -0.5rem rgba(3, 3, 3, 0.2);
+  --pf-global--BoxShadow--xl-bottom: 0 1rem 1rem -0.5rem rgba(3, 3, 3, 0.2);
+  --pf-global--BoxShadow--xl-left: -1rem 0 1rem -0.5rem rgba(3, 3, 3, 0.2);
+  --pf-global--BoxShadow--inset: inset 0 0 0.625rem 0 rgba(3, 3, 3, 0.25);
+  --pf-global--spacer--xs: 0.25rem;
+  --pf-global--spacer--sm: 0.5rem;
+  --pf-global--spacer--md: 1rem;
+  --pf-global--spacer--lg: 1.5rem;
+  --pf-global--spacer--xl: 2rem;
+  --pf-global--spacer--2xl: 3rem;
+  --pf-global--spacer--3xl: 4rem;
+  --pf-global--spacer--4xl: 5rem;
+  --pf-global--spacer--form-element: 0.375rem;
+  --pf-global--gutter: 1rem;
+  --pf-global--gutter--md: 1.5rem;
+  --pf-global--ZIndex--xs: 100;
+  --pf-global--ZIndex--sm: 200;
+  --pf-global--ZIndex--md: 300;
+  --pf-global--ZIndex--lg: 400;
+  --pf-global--ZIndex--xl: 500;
+  --pf-global--ZIndex--2xl: 600;
+  --pf-global--breakpoint--xs: 0;
+  --pf-global--breakpoint--sm: 576px;
+  --pf-global--breakpoint--md: 768px;
+  --pf-global--breakpoint--lg: 992px;
+  --pf-global--breakpoint--xl: 1200px;
+  --pf-global--breakpoint--2xl: 1450px;
+  --pf-global--link--Color: #06c;
+  --pf-global--link--Color--hover: #004080;
+  --pf-global--link--Color--light: #2b9af3;
+  --pf-global--link--Color--light--hover: #73bcf7;
+  --pf-global--link--Color--dark: #06c;
+  --pf-global--link--Color--dark--hover: #004080;
+  --pf-global--link--Color--visited: #40199a;
+  --pf-global--link--TextDecoration: none;
+  --pf-global--link--TextDecoration--hover: underline;
+  --pf-global--BorderWidth--sm: 1px;
+  --pf-global--BorderWidth--md: 2px;
+  --pf-global--BorderWidth--lg: 3px;
+  --pf-global--BorderWidth--xl: 4px;
+  --pf-global--BorderColor--100: #d2d2d2;
+  --pf-global--BorderColor--200: #8a8d90;
+  --pf-global--BorderColor--300: #f0f0f0;
+  --pf-global--BorderColor--dark-100: #d2d2d2;
+  --pf-global--BorderColor--light-100: #b8bbbe;
+  --pf-global--BorderRadius--sm: 3px;
+  --pf-global--BorderRadius--lg: 30em;
+  --pf-global--icon--Color--light: #6a6e73;
+  --pf-global--icon--Color--dark: #151515;
+  --pf-global--icon--FontSize--sm: 0.625rem;
+  --pf-global--icon--FontSize--md: 1.125rem;
+  --pf-global--icon--FontSize--lg: 1.5rem;
+  --pf-global--icon--FontSize--xl: 3.375rem;
+  --pf-global--FontFamily--sans-serif: "RedHatText", "Overpass", overpass, helvetica, arial, sans-serif;
+  --pf-global--FontFamily--heading--sans-serif: "RedHatDisplay", "Overpass", overpass, helvetica, arial, sans-serif;
+  --pf-global--FontFamily--monospace: "Liberation Mono", consolas, "SFMono-Regular", menlo, monaco, "Courier New",
+    monospace;
+  --pf-global--FontFamily--overpass--sans-serif: "overpass", overpass, "open sans", -apple-system, blinkmacsystemfont,
+    "Segoe UI", roboto, "Helvetica Neue", arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  --pf-global--FontFamily--overpass--monospace: "overpass-mono", overpass-mono, "SFMono-Regular", menlo, monaco,
+    consolas, "Liberation Mono", "Courier New", monospace;
+  --pf-global--FontSize--4xl: 2.25rem;
+  --pf-global--FontSize--3xl: 1.75rem;
+  --pf-global--FontSize--2xl: 1.5rem;
+  --pf-global--FontSize--xl: 1.25rem;
+  --pf-global--FontSize--lg: 1.125rem;
+  --pf-global--FontSize--md: 1rem;
+  --pf-global--FontSize--sm: 0.875rem;
+  --pf-global--FontSize--xs: 0.75rem;
+  --pf-global--FontWeight--light: 300;
+  --pf-global--FontWeight--normal: 400;
+  --pf-global--FontWeight--semi-bold: 700;
+  --pf-global--FontWeight--overpass--semi-bold: 500;
+  --pf-global--FontWeight--bold: 700;
+  --pf-global--FontWeight--overpass--bold: 600;
+  --pf-global--LineHeight--sm: 1.3;
+  --pf-global--LineHeight--md: 1.5;
+  --pf-global--ListStyle: disc outside;
+  --pf-global--Transition: all 250ms cubic-bezier(0.42, 0, 0.58, 1);
+  --pf-global--TimingFunction: cubic-bezier(0.645, 0.045, 0.355, 1);
+  --pf-global--TransitionDuration: 250ms;
+  --pf-global--arrow--width: 0.9375rem;
+  --pf-global--arrow--width-lg: 1.5625rem;
+  --pf-global--target-size--MinWidth: 44px;
+  --pf-global--target-size--MinHeight: 44px;
+}
+
+.boxed-expression-editor .pf-m-overpass-font {
+  --pf-global--FontFamily--sans-serif: var(--pf-global--FontFamily--overpass--sans-serif);
+  --pf-global--FontFamily--heading--sans-serif: var(--pf-global--FontFamily--sans-serif);
+  --pf-global--FontFamily--monospace: var(--pf-global--FontFamily--overpass--monospace);
+  --pf-global--FontWeight--semi-bold: var(--pf-global--FontWeight--overpass--semi-bold);
+  --pf-global--FontWeight--bold: var(--pf-global--FontWeight--overpass--bold);
+}
+
+html {
+  font-size: unset !important;
+}
+
+.boxed-expression-editor .pf-screen-reader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.boxed-expression-editor .pf-svg-vertical-align {
+  vertical-align: -0.125em;
+}
+
+.boxed-expression-editor .pf-t-dark.pf-m-transparent {
+  background-color: transparent;
+}
+
+.boxed-expression-editor .pf-t-dark.pf-m-transparent-100 {
+  background-color: rgba(3, 3, 3, 0.42);
+}
+
+.boxed-expression-editor .pf-t-dark.pf-m-transparent-200 {
+  background-color: rgba(3, 3, 3, 0.6);
+}
+
+.boxed-expression-editor .pf-t-dark.pf-m-opaque-100 {
+  background-color: #3c3f42;
+}
+
+.boxed-expression-editor .pf-t-dark.pf-m-opaque-200 {
+  background-color: #151515;
+}
+
+.boxed-expression-editor .pf-t-light.pf-m-transparent {
+  background-color: transparent;
+}
+
+.boxed-expression-editor .pf-t-light.pf-m-opaque-100 {
+  background-color: #fff;
+}
+
+.boxed-expression-editor .pf-t-light.pf-m-opaque-200 {
+  background-color: #fafafa;
+}
+
+.boxed-expression-editor .pf-t-light.pf-m-opaque-300 {
+  background-color: #f0f0f0;
+}
+
+.boxed-expression-editor .pf-icon-zone:before,
+.boxed-expression-editor .pf-icon-warning-triangle:before,
+.boxed-expression-editor .pf-icon-volume:before,
+.boxed-expression-editor .pf-icon-virtual-machine:before,
+.boxed-expression-editor .pf-icon-users:before,
+.boxed-expression-editor .pf-icon-user:before,
+.boxed-expression-editor .pf-icon-unplugged:before,
+.boxed-expression-editor .pf-icon-unlocked:before,
+.boxed-expression-editor .pf-icon-unknown:before,
+.boxed-expression-editor .pf-icon-trend-up:before,
+.boxed-expression-editor .pf-icon-trend-down:before,
+.boxed-expression-editor .pf-icon-topology:before,
+.boxed-expression-editor .pf-icon-thumb-tack:before,
+.boxed-expression-editor .pf-icon-tenant:before,
+.boxed-expression-editor .pf-icon-storage-domain:before,
+.boxed-expression-editor .pf-icon-spinner2:before,
+.boxed-expression-editor .pf-icon-spinner:before,
+.boxed-expression-editor .pf-icon-services:before,
+.boxed-expression-editor .pf-icon-service:before,
+.boxed-expression-editor .pf-icon-service-catalog:before,
+.boxed-expression-editor .pf-icon-server:before,
+.boxed-expression-editor .pf-icon-server-group:before,
+.boxed-expression-editor .pf-icon-security:before,
+.boxed-expression-editor .pf-icon-screen:before,
+.boxed-expression-editor .pf-icon-save:before,
+.boxed-expression-editor .pf-icon-running:before,
+.boxed-expression-editor .pf-icon-resources-full:before,
+.boxed-expression-editor .pf-icon-resources-empty:before,
+.boxed-expression-editor .pf-icon-resources-almost-full:before,
+.boxed-expression-editor .pf-icon-resources-almost-empty:before,
+.boxed-expression-editor .pf-icon-resource-pool:before,
+.boxed-expression-editor .pf-icon-repository:before,
+.boxed-expression-editor .pf-icon-replicator:before,
+.boxed-expression-editor .pf-icon-remove2:before,
+.boxed-expression-editor .pf-icon-registry:before,
+.boxed-expression-editor .pf-icon-regions:before,
+.boxed-expression-editor .pf-icon-rebooting:before,
+.boxed-expression-editor .pf-icon-rebalance:before,
+.boxed-expression-editor .pf-icon-project:before,
+.boxed-expression-editor .pf-icon-process-automation:before,
+.boxed-expression-editor .pf-icon-private:before,
+.boxed-expression-editor .pf-icon-print:before,
+.boxed-expression-editor .pf-icon-port:before,
+.boxed-expression-editor .pf-icon-plugged:before,
+.boxed-expression-editor .pf-icon-pficon-vcenter:before,
+.boxed-expression-editor .pf-icon-pficon-template:before,
+.boxed-expression-editor .pf-icon-pficon-sort-common-desc:before,
+.boxed-expression-editor .pf-icon-pficon-sort-common-asc:before,
+.boxed-expression-editor .pf-icon-pficon-satellite:before,
+.boxed-expression-editor .pf-icon-pficon-network-range:before,
+.boxed-expression-editor .pf-icon-pficon-history:before,
+.boxed-expression-editor .pf-icon-pficon-dragdrop:before,
+.boxed-expression-editor .pf-icon-pending:before,
+.boxed-expression-editor .pf-icon-paused:before,
+.boxed-expression-editor .pf-icon-panel-open:before,
+.boxed-expression-editor .pf-icon-panel-close:before,
+.boxed-expression-editor .pf-icon-package:before,
+.boxed-expression-editor .pf-icon-os-image:before,
+.boxed-expression-editor .pf-icon-orders:before,
+.boxed-expression-editor .pf-icon-optimize:before,
+.boxed-expression-editor .pf-icon-openstack:before,
+.boxed-expression-editor .pf-icon-openshift:before,
+.boxed-expression-editor .pf-icon-on:before,
+.boxed-expression-editor .pf-icon-on-running:before,
+.boxed-expression-editor .pf-icon-ok:before,
+.boxed-expression-editor .pf-icon-off:before,
+.boxed-expression-editor .pf-icon-not-started:before,
+.boxed-expression-editor .pf-icon-new-process:before,
+.boxed-expression-editor .pf-icon-network:before,
+.boxed-expression-editor .pf-icon-namespaces:before,
+.boxed-expression-editor .pf-icon-monitoring:before,
+.boxed-expression-editor .pf-icon-module:before,
+.boxed-expression-editor .pf-icon-migration:before,
+.boxed-expression-editor .pf-icon-middleware:before,
+.boxed-expression-editor .pf-icon-messages:before,
+.boxed-expression-editor .pf-icon-memory:before,
+.boxed-expression-editor .pf-icon-maintenance:before,
+.boxed-expression-editor .pf-icon-locked:before,
+.boxed-expression-editor .pf-icon-key:before,
+.boxed-expression-editor .pf-icon-integration:before,
+.boxed-expression-editor .pf-icon-infrastructure:before,
+.boxed-expression-editor .pf-icon-info:before,
+.boxed-expression-editor .pf-icon-in-progress:before,
+.boxed-expression-editor .pf-icon-import:before,
+.boxed-expression-editor .pf-icon-home:before,
+.boxed-expression-editor .pf-icon-history:before,
+.boxed-expression-editor .pf-icon-help:before,
+.boxed-expression-editor .pf-icon-globe-route:before,
+.boxed-expression-editor .pf-icon-folder-open:before,
+.boxed-expression-editor .pf-icon-folder-close:before,
+.boxed-expression-editor .pf-icon-flavor:before,
+.boxed-expression-editor .pf-icon-filter:before,
+.boxed-expression-editor .pf-icon-export:before,
+.boxed-expression-editor .pf-icon-error-circle-o:before,
+.boxed-expression-editor .pf-icon-equalizer:before,
+.boxed-expression-editor .pf-icon-enterprise:before,
+.boxed-expression-editor .pf-icon-enhancement:before,
+.boxed-expression-editor .pf-icon-edit:before,
+.boxed-expression-editor .pf-icon-domain:before,
+.boxed-expression-editor .pf-icon-disconnected:before,
+.boxed-expression-editor .pf-icon-degraded:before,
+.boxed-expression-editor .pf-icon-cpu:before,
+.boxed-expression-editor .pf-icon-container-node:before,
+.boxed-expression-editor .pf-icon-connected:before,
+.boxed-expression-editor .pf-icon-cluster:before,
+.boxed-expression-editor .pf-icon-cloud-tenant:before,
+.boxed-expression-editor .pf-icon-cloud-security:before,
+.boxed-expression-editor .pf-icon-close:before,
+.boxed-expression-editor .pf-icon-chat:before,
+.boxed-expression-editor .pf-icon-catalog:before,
+.boxed-expression-editor .pf-icon-bundle:before,
+.boxed-expression-editor .pf-icon-builder-image:before,
+.boxed-expression-editor .pf-icon-build:before,
+.boxed-expression-editor .pf-icon-blueprint:before,
+.boxed-expression-editor .pf-icon-bell:before,
+.boxed-expression-editor .pf-icon-automation:before,
+.boxed-expression-editor .pf-icon-attention-bell:before,
+.boxed-expression-editor .pf-icon-asleep:before,
+.boxed-expression-editor .pf-icon-arrow:before,
+.boxed-expression-editor .pf-icon-applications:before,
+.boxed-expression-editor .pf-icon-ansible-tower:before,
+.boxed-expression-editor .pf-icon-add-circle-o:before {
+  font-family: "pficon", emoji;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-style: normal;
+  font-variant: normal;
+  font-weight: normal;
+  text-decoration: none;
+  text-transform: none;
+}
+
+.boxed-expression-editor .pf-icon-add-circle-o:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-ansible-tower:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-applications:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-arrow:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-asleep:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-attention-bell:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-automation:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-bell:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-blueprint:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-build:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-builder-image:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-bundle:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-catalog:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-chat:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-close:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-cloud-security:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-cloud-tenant:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-cluster:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-connected:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-container-node:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-cpu:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-degraded:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-disconnected:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-domain:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-edit:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-enhancement:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-enterprise:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-equalizer:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-error-circle-o:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-export:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-filter:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-flavor:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-folder-close:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-folder-open:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-globe-route:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-help:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-history:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-home:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-import:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-in-progress:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-info:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-infrastructure:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-integration:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-key:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-locked:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-maintenance:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-memory:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-messages:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-middleware:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-migration:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-module:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-monitoring:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-namespaces:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-network:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-new-process:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-not-started:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-off:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-ok:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-on-running:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-on:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-openshift:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-openstack:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-optimize:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-orders:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-os-image:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-package:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-panel-close:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-panel-open:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-paused:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-pending:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-pficon-dragdrop:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-pficon-history:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-pficon-network-range:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-pficon-satellite:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-pficon-sort-common-asc:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-pficon-sort-common-desc:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-pficon-template:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-pficon-vcenter:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-plugged:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-port:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-print:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-private:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-process-automation:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-project:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-rebalance:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-rebooting:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-regions:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-registry:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-remove2:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-replicator:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-repository:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-resource-pool:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-resources-almost-empty:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-resources-almost-full:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-resources-empty:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-resources-full:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-running:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-save:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-screen:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-security:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-server-group:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-server:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-service-catalog:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-service:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-services:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-spinner:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-spinner2:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-storage-domain:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-tenant:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-thumb-tack:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-topology:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-trend-down:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-trend-up:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-unknown:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-unlocked:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-unplugged:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-user:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-users:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-virtual-machine:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-volume:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-warning-triangle:before {
+  content: "";
+}
+
+.boxed-expression-editor .pf-icon-zone:before {
+  content: "";
+}


### PR DESCRIPTION
Fixing CSS rules compatibility issue with keyboard shortcuts section, due to inclusion `react-core` inside the `boxed-expression-component`, provided by PF.
![image](https://user-images.githubusercontent.com/22591802/140073099-b5148bd8-3d07-4001-9348-d3ca381c9be7.png)
