### PR TITLE
KOGITO-6181: Stunner-based editors are loosing focus when asked for the SVG

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/LienzoCanvas.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/LienzoCanvas.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import javax.enterprise.event.Event;
 
 import com.ait.lienzo.client.core.config.LienzoCore;
+import com.ait.lienzo.client.core.shape.Layer;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.ViewEventHandlerManager;
 import org.kie.workbench.common.stunner.client.lienzo.util.LienzoLayerUtils;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
@@ -68,7 +69,11 @@ public abstract class LienzoCanvas<V extends LienzoCanvasView>
                                  final ViewEventHandlerManager viewEventHandlerManager) {
         LienzoCore.get().setHidpiEnabled(settings.isHiDPIEnabled());
         this.eventHandlerManager = viewEventHandlerManager;
-        return super.initialize(panel, settings);
+
+        super.initialize(panel, settings);
+        Layer toplayer = new Layer().setListening(true);
+        getView().getLayer().getLienzoLayer().getScene().add(toplayer);
+        return this;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoMultipleSelectionControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoMultipleSelectionControl.java
@@ -174,12 +174,6 @@ public class LienzoMultipleSelectionControl<H extends AbstractCanvasHandler>
     }
 
     @Override
-    protected void handleCanvasClearSelectionEvent(CanvasClearSelectionEvent event) {
-        super.handleCanvasClearSelectionEvent(event);
-        onClearSelection();;
-    }
-
-    @Override
     protected void onDestroy() {
         getSelectionManager().destroy();
         selectionShapeProvider.destroy();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoMultipleSelectionControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoMultipleSelectionControl.java
@@ -174,6 +174,12 @@ public class LienzoMultipleSelectionControl<H extends AbstractCanvasHandler>
     }
 
     @Override
+    protected void handleCanvasClearSelectionEvent(CanvasClearSelectionEvent event) {
+        super.handleCanvasClearSelectionEvent(event);
+        onClearSelection();;
+    }
+
+    @Override
     protected void onDestroy() {
         getSelectionManager().destroy();
         selectionShapeProvider.destroy();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/toolbox/actions/AbstractActionsToolboxView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/toolbox/actions/AbstractActionsToolboxView.java
@@ -91,9 +91,17 @@ public abstract class AbstractActionsToolboxView<V extends AbstractActionsToolbo
     public void destroy() {
         Optional.ofNullable(toolboxView).ifPresent(WiresShapeToolbox::destroy);
         Optional.ofNullable(tooltip).ifPresent(ToolboxTextTooltip::destroy);
+
+        drawTopLayer();
+
         toolboxView = null;
         tooltip = null;
         canvas = null;
+    }
+
+    protected void drawTopLayer() {
+        canvas.getView().getLayer().getTopLayer().setVisible(true);
+        canvas.getView().getLayer().getTopLayer().draw();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/components/toolbox/actions/AbstractActionsToolboxViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/components/toolbox/actions/AbstractActionsToolboxViewTest.java
@@ -35,6 +35,7 @@ import com.ait.lienzo.client.core.shape.toolbox.items.tooltip.ToolboxTextTooltip
 import com.ait.lienzo.client.core.shape.toolbox.items.tooltip.TooltipFactory;
 import com.ait.lienzo.client.core.shape.wires.WiresShape;
 import com.ait.lienzo.client.core.types.BoundingBox;
+import org.junit.Test;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresCanvas;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresCanvasView;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresLayer;
@@ -42,10 +43,12 @@ import org.kie.workbench.common.stunner.client.lienzo.components.glyph.LienzoGly
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.ActionsToolbox;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -166,4 +169,18 @@ public abstract class AbstractActionsToolboxViewTest {
         verify(canvasView,
                times(1)).setCursor(eq(AbstractCanvas.Cursors.DEFAULT));
     }
+
+    @Mock
+    AbstractActionsToolboxView toolboxView2;
+
+    @Test
+    public void testDestroyTopLayerRepaint() {
+        doCallRealMethod().when(toolboxView2).destroy();
+
+        toolboxView2.destroy();
+        verify(toolboxView2,
+               times(1)).drawTopLayer();
+    }
+
+
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasFileExport.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasFileExport.java
@@ -54,11 +54,9 @@ public class CanvasFileExport {
     private final FileExport<PdfDocument> pdfFileExport;
     private final FileExportsPreferences preferences;
     private final SvgFileExport svgFileExport;
-    private final Event<CanvasClearSelectionEvent> clearSelectionEvent;
 
     protected CanvasFileExport() {
         this(null,
-             null,
              null,
              null,
              null,
@@ -70,41 +68,31 @@ public class CanvasFileExport {
                             final FileExport<ImageDataUriContent> imageFileExport,
                             final FileExport<PdfDocument> pdfFileExport,
                             final FileExportsPreferences preferences,
-                            final SvgFileExport svgFileExport,
-                            final Event<CanvasClearSelectionEvent> clearSelectionEvent) {
+                            final SvgFileExport svgFileExport) {
         this.canvasExport = canvasExport;
         this.imageFileExport = imageFileExport;
         this.pdfFileExport = pdfFileExport;
         this.preferences = preferences;
         this.svgFileExport = svgFileExport;
-        this.clearSelectionEvent = clearSelectionEvent;
     }
 
     public void exportToSvg(final AbstractCanvasHandler canvasHandler,
                             final String fileName) {
-        clearSelection(canvasHandler);
         final String fullFileName = fileName + "." + getFileExtension(CanvasExport.URLDataType.SVG);
         svgFileExport.export(canvasExport.toContext2D(canvasHandler, CanvasExportSettings.build()), fullFileName);
     }
 
-    void clearSelection(AbstractCanvasHandler canvasHandler) {
-        clearSelectionEvent.fire(new CanvasClearSelectionEvent(canvasHandler));
-    }
-
     public String exportToSvg(final AbstractCanvasHandler canvasHandler) {
-        clearSelection(canvasHandler);
         return canvasExport.toContext2D(canvasHandler, CanvasExportSettings.build()).getSerializedSvg();
     }
 
     public String exportToPng(final AbstractCanvasHandler canvasHandler) {
         final CanvasURLExportSettings settings = CanvasURLExportSettings.build(CanvasExport.URLDataType.PNG);
-        clearSelection(canvasHandler);
         return canvasExport.toImageData(canvasHandler, settings);
     }
 
     public void exportToJpg(final AbstractCanvasHandler canvasHandler,
                             final String fileName) {
-        clearSelection(canvasHandler);
         exportImage(canvasHandler,
                     CanvasExport.URLDataType.JPG,
                     fileName);
@@ -112,7 +100,6 @@ public class CanvasFileExport {
 
     public void exportToPng(final AbstractCanvasHandler canvasHandler,
                             final String fileName) {
-        clearSelection(canvasHandler);
         exportImage(canvasHandler,
                     CanvasExport.URLDataType.PNG,
                     fileName);
@@ -120,7 +107,6 @@ public class CanvasFileExport {
 
     public void exportToPdf(final AbstractCanvasHandler canvasHandler,
                             final String fileName) {
-        clearSelection(canvasHandler);
         loadFileExportPreferences(prefs -> exportToPdf(canvasHandler,
                                                        fileName,
                                                        prefs.getPdfPreferences()));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasFileExport.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasFileExport.java
@@ -20,11 +20,9 @@ import java.util.function.Consumer;
 import java.util.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.export.CanvasExport;
 import org.kie.workbench.common.stunner.core.client.canvas.export.CanvasExportSettings;
 import org.kie.workbench.common.stunner.core.client.canvas.export.CanvasURLExportSettings;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasFileExport.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasFileExport.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.core.client.canvas.util;
 
+import java.util.Collection;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
@@ -23,11 +24,14 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.export.CanvasExport;
 import org.kie.workbench.common.stunner.core.client.canvas.export.CanvasExportSettings;
 import org.kie.workbench.common.stunner.core.client.canvas.export.CanvasURLExportSettings;
+import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.uberfire.ext.editor.commons.client.file.exports.FileExport;
 import org.uberfire.ext.editor.commons.client.file.exports.ImageDataUriContent;
 import org.uberfire.ext.editor.commons.client.file.exports.PdfDocument;
@@ -55,9 +59,13 @@ public class CanvasFileExport {
     private final FileExportsPreferences preferences;
     private final SvgFileExport svgFileExport;
     private final Event<CanvasClearSelectionEvent> clearSelectionEvent;
+    private final SessionManager sessionManager;
+    private final Event<CanvasSelectionEvent> selectionEvent;
 
     protected CanvasFileExport() {
         this(null,
+             null,
+             null,
              null,
              null,
              null,
@@ -71,59 +79,89 @@ public class CanvasFileExport {
                             final FileExport<PdfDocument> pdfFileExport,
                             final FileExportsPreferences preferences,
                             final SvgFileExport svgFileExport,
-                            final Event<CanvasClearSelectionEvent> clearSelectionEvent) {
+                            final Event<CanvasClearSelectionEvent> clearSelectionEvent,
+                            final SessionManager sessionManager,
+                            final Event<CanvasSelectionEvent> selectionEvent) {
         this.canvasExport = canvasExport;
         this.imageFileExport = imageFileExport;
         this.pdfFileExport = pdfFileExport;
         this.preferences = preferences;
         this.svgFileExport = svgFileExport;
         this.clearSelectionEvent = clearSelectionEvent;
+        this.sessionManager = sessionManager;
+        this.selectionEvent = selectionEvent;
     }
 
     public void exportToSvg(final AbstractCanvasHandler canvasHandler,
                             final String fileName) {
+        final Collection<String> selectedItems = getSelectedItems();
         clearSelection(canvasHandler);
         final String fullFileName = fileName + "." + getFileExtension(CanvasExport.URLDataType.SVG);
         svgFileExport.export(canvasExport.toContext2D(canvasHandler, CanvasExportSettings.build()), fullFileName);
+        fireSelectionEvent(canvasHandler, selectedItems);
     }
 
     void clearSelection(AbstractCanvasHandler canvasHandler) {
-        clearSelectionEvent.fire(new CanvasClearSelectionEvent(canvasHandler));
+        clearSelectionEvent.fire( new CanvasClearSelectionEvent(canvasHandler));
     }
 
     public String exportToSvg(final AbstractCanvasHandler canvasHandler) {
+        final Collection<String> selectedItems = getSelectedItems();
         clearSelection(canvasHandler);
-        return canvasExport.toContext2D(canvasHandler, CanvasExportSettings.build()).getSerializedSvg();
+        String serializedSvg = canvasExport.toContext2D(canvasHandler, CanvasExportSettings.build()).getSerializedSvg();
+        fireSelectionEvent(canvasHandler, selectedItems);
+        return serializedSvg;
+    }
+
+    private void fireSelectionEvent(AbstractCanvasHandler canvasHandler, Collection<String> selectedItems) {
+        if (!selectedItems.isEmpty()) {
+            selectionEvent.fire(new CanvasSelectionEvent(canvasHandler, selectedItems));
+        }
+    }
+
+    private Collection<String> getSelectedItems() {
+        final EditorSession session = sessionManager.getCurrentSession();
+        final Collection<String> selectedItems = session.getSelectionControl().getSelectedItems();
+        return selectedItems;
     }
 
     public String exportToPng(final AbstractCanvasHandler canvasHandler) {
+        final Collection<String> selectedItems = getSelectedItems();
         final CanvasURLExportSettings settings = CanvasURLExportSettings.build(CanvasExport.URLDataType.PNG);
         clearSelection(canvasHandler);
-        return canvasExport.toImageData(canvasHandler, settings);
+        final String image = canvasExport.toImageData(canvasHandler, settings);
+        fireSelectionEvent(canvasHandler, selectedItems);
+        return image;
     }
 
     public void exportToJpg(final AbstractCanvasHandler canvasHandler,
                             final String fileName) {
+        final Collection<String> selectedItems = getSelectedItems();
         clearSelection(canvasHandler);
         exportImage(canvasHandler,
                     CanvasExport.URLDataType.JPG,
                     fileName);
+        fireSelectionEvent(canvasHandler, selectedItems);
     }
 
     public void exportToPng(final AbstractCanvasHandler canvasHandler,
                             final String fileName) {
+        final Collection<String> selectedItems = getSelectedItems();
         clearSelection(canvasHandler);
         exportImage(canvasHandler,
                     CanvasExport.URLDataType.PNG,
                     fileName);
+        fireSelectionEvent(canvasHandler, selectedItems);
     }
 
     public void exportToPdf(final AbstractCanvasHandler canvasHandler,
                             final String fileName) {
+        final Collection<String> selectedItems = getSelectedItems();
         clearSelection(canvasHandler);
         loadFileExportPreferences(prefs -> exportToPdf(canvasHandler,
                                                        fileName,
                                                        prefs.getPdfPreferences()));
+        fireSelectionEvent(canvasHandler, selectedItems);
     }
 
     private void exportToPdf(final AbstractCanvasHandler canvasHandler,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasFileExportTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasFileExportTest.java
@@ -20,7 +20,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.export.CanvasExport;
 import org.kie.workbench.common.stunner.core.client.canvas.export.CanvasExportSettings;
 import org.kie.workbench.common.stunner.core.client.canvas.export.CanvasURLExportSettings;
@@ -36,13 +35,11 @@ import org.uberfire.ext.editor.commons.client.file.exports.svg.IContext2D;
 import org.uberfire.ext.editor.commons.client.file.exports.svg.SvgFileExport;
 import org.uberfire.ext.editor.commons.file.exports.FileExportsPreferences;
 import org.uberfire.ext.editor.commons.file.exports.PdfExportPreferences;
-import org.uberfire.mocks.EventSourceMock;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -85,9 +82,6 @@ public class CanvasFileExportTest {
     @Mock
     private IContext2D context2D;
 
-    @Mock
-    private EventSourceMock<CanvasClearSelectionEvent> clearSelectionEvent;
-
     @Before
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
@@ -103,8 +97,7 @@ public class CanvasFileExportTest {
                                                imageFileExport,
                                                pdfFileExport,
                                                preferences,
-                                               svgFileExport,
-                                               clearSelectionEvent));
+                                               svgFileExport));
     }
 
     @Test
@@ -124,7 +117,6 @@ public class CanvasFileExportTest {
         final ImageDataUriContent imageDataUriContent = contentArgumentCaptor.getValue();
         assertEquals(JPG_DATA_URI,
                      imageDataUriContent.getUri());
-        verify(clearSelectionEvent).fire(any(CanvasClearSelectionEvent.class));
     }
 
     @Test
@@ -144,7 +136,6 @@ public class CanvasFileExportTest {
         final ImageDataUriContent imageDataUriContent = contentArgumentCaptor.getValue();
         assertEquals(PNG_DATA_URI,
                      imageDataUriContent.getUri());
-        verify(clearSelectionEvent).fire(any(CanvasClearSelectionEvent.class));
     }
 
     @Test
@@ -159,7 +150,6 @@ public class CanvasFileExportTest {
         verify(pdfFileExport,
                times(1)).export(any(PdfDocument.class),
                                 eq("file1.pdf"));
-        verify(clearSelectionEvent).fire(any(CanvasClearSelectionEvent.class));
     }
 
     @Test
@@ -167,7 +157,6 @@ public class CanvasFileExportTest {
         when(canvasExport.toContext2D(eq(canvasHandler), any(CanvasExportSettings.class))).thenReturn(context2D);
         tested.exportToSvg(canvasHandler, "file1");
         verify(svgFileExport, times(1)).export(context2D, "file1.svg");
-        verify(clearSelectionEvent).fire(any(CanvasClearSelectionEvent.class));
     }
 
     @Test
@@ -175,12 +164,10 @@ public class CanvasFileExportTest {
 
         final String expectedImage = "image";
 
-        doNothing().when(tested).clearSelection(any());
         when(canvasExport.toImageData(any(), any())).thenReturn(expectedImage);
 
         final String actualImage = tested.exportToPng(canvasHandler);
 
-        verify(tested).clearSelection(canvasHandler);
         assertEquals(expectedImage, actualImage);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasFileExportTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasFileExportTest.java
@@ -16,21 +16,14 @@
 
 package org.kie.workbench.common.stunner.core.client.canvas.util;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.controls.SelectionControl;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.export.CanvasExport;
 import org.kie.workbench.common.stunner.core.client.canvas.export.CanvasExportSettings;
 import org.kie.workbench.common.stunner.core.client.canvas.export.CanvasURLExportSettings;
-import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.mockito.ArgumentCaptor;
@@ -79,9 +72,6 @@ public class CanvasFileExportTest {
     private AbstractCanvasHandler canvasHandler;
 
     @Mock
-    private SessionManager sessionManager;
-
-    @Mock
     private Diagram diagram;
 
     @Mock
@@ -98,28 +88,9 @@ public class CanvasFileExportTest {
     @Mock
     private EventSourceMock<CanvasClearSelectionEvent> clearSelectionEvent;
 
-    @Mock
-    private EventSourceMock<CanvasSelectionEvent> selectionEvent;
-
-    @Mock
-    EditorSession session;
-
-    @Mock
-    private SelectionControl selectionControl;
-
-
     @Before
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
-        when(sessionManager.getCurrentSession()).thenReturn(session);
-        when(session.getSelectionControl()).thenReturn(selectionControl);
-        final Collection<String> selectedItems = new ArrayList<String>(3) {{
-            add("someId1");
-            add("someId2");
-            add("someId3");
-        }};
-
-        when(selectionControl.getSelectedItems()).thenReturn(selectedItems);
         when(canvasHandler.getDiagram()).thenReturn(diagram);
         when(diagram.getMetadata()).thenReturn(metadata);
         when(metadata.getTitle()).thenReturn(TITLE);
@@ -133,9 +104,7 @@ public class CanvasFileExportTest {
                                                pdfFileExport,
                                                preferences,
                                                svgFileExport,
-                                               clearSelectionEvent,
-                                               sessionManager,
-                                               selectionEvent));
+                                               clearSelectionEvent));
     }
 
     @Test
@@ -156,7 +125,6 @@ public class CanvasFileExportTest {
         assertEquals(JPG_DATA_URI,
                      imageDataUriContent.getUri());
         verify(clearSelectionEvent).fire(any(CanvasClearSelectionEvent.class));
-        verify(selectionEvent).fire(any(CanvasSelectionEvent.class));
     }
 
     @Test
@@ -177,7 +145,6 @@ public class CanvasFileExportTest {
         assertEquals(PNG_DATA_URI,
                      imageDataUriContent.getUri());
         verify(clearSelectionEvent).fire(any(CanvasClearSelectionEvent.class));
-        verify(selectionEvent).fire(any(CanvasSelectionEvent.class));
     }
 
     @Test
@@ -193,7 +160,6 @@ public class CanvasFileExportTest {
                times(1)).export(any(PdfDocument.class),
                                 eq("file1.pdf"));
         verify(clearSelectionEvent).fire(any(CanvasClearSelectionEvent.class));
-        verify(selectionEvent).fire(any(CanvasSelectionEvent.class));
     }
 
     @Test
@@ -202,7 +168,6 @@ public class CanvasFileExportTest {
         tested.exportToSvg(canvasHandler, "file1");
         verify(svgFileExport, times(1)).export(context2D, "file1.svg");
         verify(clearSelectionEvent).fire(any(CanvasClearSelectionEvent.class));
-        verify(selectionEvent).fire(any(CanvasSelectionEvent.class));
     }
 
     @Test
@@ -217,6 +182,5 @@ public class CanvasFileExportTest {
 
         verify(tested).clearSelection(canvasHandler);
         assertEquals(expectedImage, actualImage);
-        verify(selectionEvent).fire(any(CanvasSelectionEvent.class));
     }
 }


### PR DESCRIPTION
Hi @romartin can you review this PR? As discussed, unselection is disabled for SVG, PNG, JPG and PDF