### PR TITLE
Remove duplicit gwt-maven-plugin definition

### DIFF
--- a/lienzo-webapp/pom.xml
+++ b/lienzo-webapp/pom.xml
@@ -230,23 +230,6 @@
 							<modules>
 								<module>org.kie.lienzo.LienzoShowcase</module>
 							</modules>
-						</configuration>
-					</plugin>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>gwt-maven-plugin</artifactId>
-						<executions>
-							<execution>
-								<goals>
-									<goal>compile</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<runTarget>LienzoShowcase.html</runTarget>
-							<modules>
-								<module>org.kie.lienzo.LienzoShowcase</module>
-							</modules>
 							<logLevel>INFO</logLevel>
 							<noServer>false</noServer>
 							<extraJvmArgs>-Xmx2048m -XX:CompileThreshold=7000 -Djava.io.tmpdir=${project.build.directory}


### PR DESCRIPTION
This a fix for the warning from build:
Some problems were encountered while building the effective model for org.kie.kogito:lienzo-webapp:war:8.5.2-SNAPSHOT
Warning:  'profiles.profile[GWT2].plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.codehaus.mojo:gwt-maven-plugin @ line 239, column 14
Warning:
Warning:  It is highly recommended to fix these problems because they threaten the stability of your build.
Warning:
Warning:  For this reason, future Maven versions might no longer support building such malformed projects.
Warning: