### PR TITLE
Update NPM packages version before publishing

### DIFF
--- a/.github/workflows/publish_release_artifacts_npm.yml
+++ b/.github/workflows/publish_release_artifacts_npm.yml
@@ -52,6 +52,6 @@ jobs:
       - name: Publish Boxed Expression Component
         run: |
           cd ${{ github.workspace }}/kogito-editors-js/
-          npm version ${{ steps.release_tag.outputs.tag }}
+          lerna version ${{ steps.release_tag.outputs.tag }} --no-push --no-git-tag-version --exact --yes
           echo "//registry.npmjs.org/:_authToken=${{ secrets.KIEGROUP_NPM_TOKEN }}" > ~/.npmrc
           lerna exec 'npm publish --access public' --scope=boxed-expression-component --include-dependencies --stream


### PR DESCRIPTION
This PR fixes the publishing version of the [boxed-expression-component](https://www.npmjs.com/package/boxed-expression-component) and the [feel-input-component](https://www.npmjs.com/package/feel-input-component).

`npm version` changes only the kogito-editors-js `package.json`.

`lerna version` changes all kogito-editors-js packages to the specified version.