### PR TITLE
DROOLS-5197,5744 - DMN Enumeration constraint editor small enhancements

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/enumeration/DataTypeConstraintEnumeration.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/enumeration/DataTypeConstraintEnumeration.java
@@ -92,6 +92,7 @@ public class DataTypeConstraintEnumeration implements DataTypeConstraintComponen
         return getEnumerationItems()
                 .stream()
                 .map(DataTypeConstraintEnumerationItem::getValue)
+                .distinct()
                 .filter(itemValue -> !isEmpty(itemValue))
                 .collect(joining(SEPARATOR));
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/enumeration/DataTypeConstraintEnumerationView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/enumeration/DataTypeConstraintEnumerationView.java
@@ -78,6 +78,7 @@ public class DataTypeConstraintEnumerationView implements DataTypeConstraintEnum
         enumerationItem.setAttribute(DATA_POSITION, items.childNodes.length);
         items.appendChild(enumerationItem);
         getDragAndDropHelper().refreshItemsPosition();
+        presenter.scrollToBottom();
     }
 
     DragAndDropHelper getDragAndDropHelper() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/enumeration/item/DataTypeConstraintEnumerationItem.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/enumeration/item/DataTypeConstraintEnumerationItem.java
@@ -96,8 +96,8 @@ public class DataTypeConstraintEnumerationItem {
     }
 
     public void save(final String newValue) {
-        setNonNullValue(newValue);
-        refreshEnumerationListAndScrollToThisItem();
+        setValue(newValue);
+        disableEditMode();
     }
 
     public void remove() {
@@ -116,10 +116,6 @@ public class DataTypeConstraintEnumerationItem {
 
     private void refreshEnumerationList() {
         dataTypeConstraintEnumeration.refreshView();
-    }
-
-    private void refreshEnumerationListAndScrollToThisItem() {
-        dataTypeConstraintEnumeration.refreshView(getScrollToThisItemCallback());
     }
 
     Command getScrollToThisItemCallback() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/enumeration/DataTypeConstraintEnumerationTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/enumeration/DataTypeConstraintEnumerationTest.java
@@ -99,12 +99,14 @@ public class DataTypeConstraintEnumerationTest {
         final DataTypeConstraintEnumerationItem item1 = mock(DataTypeConstraintEnumerationItem.class);
         final DataTypeConstraintEnumerationItem item2 = mock(DataTypeConstraintEnumerationItem.class);
         final DataTypeConstraintEnumerationItem item3 = mock(DataTypeConstraintEnumerationItem.class);
+        final DataTypeConstraintEnumerationItem item4 = mock(DataTypeConstraintEnumerationItem.class);
 
         when(item1.getValue()).thenReturn("123");
         when(item2.getValue()).thenReturn("456");
         when(item3.getValue()).thenReturn("");
+        when(item4.getValue()).thenReturn("123");
 
-        doReturn(asList(item1, item2)).when(constraintEnumeration).getEnumerationItems();
+        doReturn(asList(item1, item2, item3, item4)).when(constraintEnumeration).getEnumerationItems();
 
         final String actualValue = constraintEnumeration.getValue();
         final String expectedValue = "123, 456";

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/enumeration/item/DataTypeConstraintEnumerationItemTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/enumeration/item/DataTypeConstraintEnumerationItemTest.java
@@ -28,7 +28,6 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.editors.types.listview.constraint.common.ConstraintPlaceholderHelper;
 import org.kie.workbench.common.dmn.client.editors.types.listview.constraint.enumeration.DataTypeConstraintEnumeration;
 import org.mockito.Mock;
-import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.constraint.enumeration.item.DataTypeConstraintEnumerationItem.NULL;
@@ -144,9 +143,6 @@ public class DataTypeConstraintEnumerationItemTest {
     public void testSave() {
 
         final String value = "123";
-        final Command command = mock(Command.class);
-
-        doReturn(command).when(enumerationItem).getScrollToThisItemCallback();
 
         enumerationItem.save(value);
 
@@ -154,16 +150,13 @@ public class DataTypeConstraintEnumerationItemTest {
         final String expected = "123";
 
         assertEquals(expected, actual);
-        verify(dataTypeConstraintEnumeration).refreshView(command);
+        verify(enumerationItem).disableEditMode();
     }
 
     @Test
     public void testSaveWhenTheValueIsBlank() {
 
         final String value = "";
-        final Command command = mock(Command.class);
-
-        doReturn(command).when(enumerationItem).getScrollToThisItemCallback();
 
         enumerationItem.save(value);
 
@@ -171,7 +164,7 @@ public class DataTypeConstraintEnumerationItemTest {
         final String expected = NULL;
 
         assertEquals(expected, actual);
-        verify(dataTypeConstraintEnumeration).refreshView(command);
+        verify(enumerationItem).disableEditMode();
     }
 
     @Test


### PR DESCRIPTION
As part of this PR we:
- prevent user from defining same enumeration item multiple times: https://issues.redhat.com/browse/DROOLS-5197
- commit all enumeration items in edit mode by click on single checkbox: https://issues.redhat.com/browse/DROOLS-5744