### PR TITLE
KOGITO-6262: Regressions on DecisionTable, after KOGITO-5078

### DIFF
--- a/kogito-editors-js/packages/boxed-expression-component/src/api/ContextEntry.ts
+++ b/kogito-editors-js/packages/boxed-expression-component/src/api/ContextEntry.ts
@@ -28,7 +28,7 @@ export interface EntryInfo {
   dataType: DataType;
 }
 
-export interface ContextEntryRecord {
+export interface ContextEntryRecord extends DataRecord {
   entryInfo: EntryInfo;
   /** Entry expression */
   entryExpression: ExpressionProps;
@@ -73,7 +73,9 @@ export const getEntryKey = (row: Row): string => {
   return entryRecord.entryInfo.name + entryRecord.entryInfo.dataType;
 };
 
-export const resetEntry = (row: DataRecord): DataRecord => ({
-  ...row,
-  entryExpression: { uid: (row.entryExpression as ExpressionProps).uid },
-});
+export function resetEntry(row: ContextEntryRecord): ContextEntryRecord {
+  return {
+    ...row,
+    entryExpression: { uid: (row.entryExpression as ExpressionProps).uid },
+  };
+}

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/ContextExpression/ContextEntryInfo.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/ContextExpression/ContextEntryInfo.tsx
@@ -16,7 +16,7 @@
 
 import "./ContextEntryInfo.css";
 import * as React from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { EditExpressionMenu } from "../EditExpressionMenu";
 import { DataType } from "../../api";
 
@@ -37,22 +37,8 @@ export const ContextEntryInfo: React.FunctionComponent<ContextEntryInfoProps> = 
   onContextEntryUpdate,
   editInfoPopoverLabel,
 }) => {
-  const [entryName, setEntryName] = useState(name);
-
-  const [entryDataType, setEntryDataType] = useState(dataType);
-
-  useEffect(() => {
-    setEntryName(name);
-  }, [name]);
-
-  useEffect(() => {
-    setEntryDataType(dataType);
-  }, [dataType]);
-
   const onEntryNameOrDataTypeUpdate = useCallback(
     ({ name, dataType }) => {
-      setEntryName(name);
-      setEntryDataType(dataType);
       onContextEntryUpdate(name, dataType);
     },
     [onContextEntryUpdate]
@@ -61,29 +47,29 @@ export const ContextEntryInfo: React.FunctionComponent<ContextEntryInfoProps> = 
   const renderEntryDefinition = useCallback(
     (additionalCssClass?: string) => (
       <div className={`entry-definition ${additionalCssClass}`}>
-        <p className="entry-name pf-u-text-truncate" title={entryName}>
-          {entryName}
+        <p className="entry-name pf-u-text-truncate" title={name}>
+          {name}
         </p>
-        <p className="entry-data-type pf-u-text-truncate" title={entryDataType}>
-          ({entryDataType})
+        <p className="entry-data-type pf-u-text-truncate" title={dataType}>
+          ({dataType})
         </p>
       </div>
     ),
-    [entryDataType, entryName]
+    [dataType, name]
   );
 
   const renderEntryDefinitionWithPopoverMenu = useMemo(
     () => (
       <EditExpressionMenu
         title={editInfoPopoverLabel}
-        selectedExpressionName={entryName}
-        selectedDataType={entryDataType}
+        selectedExpressionName={name}
+        selectedDataType={dataType}
         onExpressionUpdate={onEntryNameOrDataTypeUpdate}
       >
         {renderEntryDefinition("with-popover-menu")}
       </EditExpressionMenu>
     ),
-    [editInfoPopoverLabel, entryDataType, entryName, onEntryNameOrDataTypeUpdate, renderEntryDefinition]
+    [editInfoPopoverLabel, dataType, name, onEntryNameOrDataTypeUpdate, renderEntryDefinition]
   );
 
   return (

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/ContextExpression/ContextExpression.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/ContextExpression/ContextExpression.tsx
@@ -52,7 +52,7 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = (context
 
   const rows = useMemo(
     () =>
-      contextExpression.contextEntries || [
+      contextExpression.contextEntries ?? [
         {
           entryInfo: {
             name: DEFAULT_CONTEXT_ENTRY_NAME,
@@ -229,8 +229,11 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = (context
     return getEntryKey(row);
   }, []);
 
-  const resetRowCustomFunction = useCallback((row: DataRecord) => {
-    return resetEntry(row);
+  const resetRowCustomFunction = useCallback((row: ContextEntryRecord) => {
+    const updatedRow = resetEntry(row);
+    updatedRow.entryExpression.name = updatedRow.entryInfo.name ?? DEFAULT_CONTEXT_ENTRY_NAME;
+    updatedRow.entryExpression.dataType = updatedRow.entryInfo.dataType ?? DEFAULT_CONTEXT_ENTRY_DATA_TYPE;
+    return updatedRow;
   }, []);
 
   const onHorizontalResizeStop = useCallback(

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/ContextExpression/ContextExpression.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/ContextExpression/ContextExpression.tsx
@@ -85,15 +85,14 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = (context
         ...contextExpressionUpdated,
       };
 
-      const expression = _.omit(updatedDefinition, ["name", "dataType"]);
       executeIfExpressionDefinitionChanged(
         contextExpression,
         updatedDefinition,
         () => {
           if (contextExpression.isHeadless) {
-            contextExpression.onUpdatingRecursiveExpression?.(expression);
+            contextExpression.onUpdatingRecursiveExpression?.(updatedDefinition);
           } else {
-            setSupervisorHash(hashfy(expression));
+            setSupervisorHash(hashfy(updatedDefinition));
             window.beeApi?.broadcastContextExpressionDefinition?.(updatedDefinition as ContextProps);
           }
         },

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/DecisionTableExpression/DecisionTableExpression.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/DecisionTableExpression/DecisionTableExpression.tsx
@@ -240,7 +240,7 @@ export function DecisionTableExpression(decisionTable: PropsWithChildren<Decisio
           () => {
             decisionTable.onUpdatingRecursiveExpression?.(headlessDefinition);
           },
-          ["hitPolicy", "aggregation", "input", "output", "annotations", "rules"]
+          ["name", "dataType", "hitPolicy", "aggregation", "input", "output", "annotations", "rules"]
         );
       } else {
         executeIfExpressionDefinitionChanged(
@@ -279,7 +279,9 @@ export function DecisionTableExpression(decisionTable: PropsWithChildren<Decisio
   const onColumnsUpdate = useCallback(
     (updatedColumns) => {
       const decisionNodeColumn = _.find(updatedColumns, { groupType: DecisionTableColumnType.OutputClause });
-      synchronizeDecisionNodeDataTypeWithSingleOutputColumnDataType(decisionNodeColumn);
+      if (!decisionTable.isHeadless) {
+        synchronizeDecisionNodeDataTypeWithSingleOutputColumnDataType(decisionNodeColumn);
+      }
       spreadDecisionTableExpressionDefinition(
         {
           name: decisionNodeColumn.label,

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/DecisionTableExpression/DecisionTableExpression.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/DecisionTableExpression/DecisionTableExpression.tsx
@@ -233,7 +233,7 @@ export function DecisionTableExpression(decisionTable: PropsWithChildren<Decisio
       };
 
       if (decisionTable.isHeadless) {
-        const headlessDefinition = _.omit(updatedDefinition, ["name", "dataType", "isHeadless"]);
+        const headlessDefinition = _.omit(updatedDefinition, ["isHeadless"]);
         executeIfExpressionDefinitionChanged(
           decisionTable,
           headlessDefinition,

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/Table/Table.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/Table/Table.tsx
@@ -92,7 +92,10 @@ export const Table: React.FunctionComponent<TableProps> = ({
   const onRowAddingCallback = useCallback(() => {
     return onRowAdding ? onRowAdding() : {};
   }, [onRowAdding]);
-  const onGetColumnPrefix = useCallback(() => (getColumnPrefix ? getColumnPrefix() : "column-"), [getColumnPrefix]);
+  const onGetColumnPrefix = useCallback(
+    (groupType?: string) => (getColumnPrefix ? getColumnPrefix(groupType) : "column-"),
+    [getColumnPrefix]
+  );
 
   const globalContext = useContext(BoxedExpressionGlobalContext);
 

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/Table/TableHandler.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/Table/TableHandler.tsx
@@ -153,10 +153,11 @@ export const TableHandler: React.FunctionComponent<TableHandlerProps> = ({
   /** These column operations have impact also on the collection of cells */
   const updateColumnsThenRows = useCallback(
     (operation?: TableOperation, columnIndex?: number, updatedColumns?: any) => {
-      updatedColumns
-        ? onColumnsUpdate([...updatedColumns], operation, columnIndex)
-        : onColumnsUpdate([...tableColumns], operation, columnIndex);
-
+      if (updatedColumns) {
+        onColumnsUpdate([...updatedColumns], operation, columnIndex);
+      } else {
+        onColumnsUpdate([...tableColumns], operation, columnIndex);
+      }
       onRowsUpdate([...tableRows.current]);
     },
     [onColumnsUpdate, onRowsUpdate, tableColumns, tableRows]


### PR DESCRIPTION
## JIRA
https://issues.redhat.com/browse/KOGITO-6262

## On this PR
Fix both issues reported on KOGITO-6262

- New columns have the correct name
https://user-images.githubusercontent.com/24302289/143435767-504efd57-0405-4b8f-b84b-0abefc12af7d.mp4

- The DecisionTableExpression name is now syncronized with its parent.
https://user-images.githubusercontent.com/24302289/143435792-5c7726ee-81cb-4dab-87a1-d246cbbf39b8.mp4


 