### PR TITLE
KOGITO-6168/KOGITO-6194 : Provide additional JS Methods

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -55,6 +55,8 @@ import org.kie.workbench.common.stunner.core.client.command.SessionCommandManage
 import org.kie.workbench.common.stunner.core.client.components.layout.LayoutHelper;
 import org.kie.workbench.common.stunner.core.client.components.layout.OpenDiagramLayoutExecutor;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.core.client.shape.Shape;
+import org.kie.workbench.common.stunner.core.client.shape.ShapeState;
 import org.kie.workbench.common.stunner.core.client.util.WindowJSType;
 import org.kie.workbench.common.stunner.core.documentation.DocumentationView;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
@@ -155,7 +157,30 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
         if (canvas != null) {
             LienzoPanel panel = (LienzoPanel) canvas.getView().getPanel();
             LienzoBoundsPanel lienzoPanel = panel.getView();
-            JsCanvas jsCanvas = new JsCanvas(lienzoPanel, lienzoPanel.getLayer());
+            JsCanvas jsCanvas = new JsCanvas(lienzoPanel, lienzoPanel.getLayer(), (UUID, state) -> {
+                Shape shape = stunnerEditor.getCanvasHandler().getCanvas().getShape(UUID);
+                if (shape != null) {
+                    ShapeState shapeState = null;
+                    switch (state) {
+                        case "None":
+                            shapeState = ShapeState.NONE;
+                            break;
+                        case "Selected":
+                            shapeState = ShapeState.SELECTED;
+                            break;
+                        case "Highlight":
+                            shapeState = ShapeState.HIGHLIGHT;
+                            break;
+                        case "Invalid":
+                            shapeState = ShapeState.INVALID;
+                            break;
+                    }
+
+                    if (shapeState != null) {
+                        shape.applyState(shapeState);
+                    }
+                }
+            });
             setupJsCanvasTypeNative(jsCanvas);
         }
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -161,17 +161,17 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
                 Shape shape = stunnerEditor.getCanvasHandler().getCanvas().getShape(UUID);
                 if (shape != null) {
                     ShapeState shapeState = null;
-                    switch (state) {
-                        case "None":
+                    switch (state.toLowerCase()) {
+                        case "none":
                             shapeState = ShapeState.NONE;
                             break;
-                        case "Selected":
+                        case "selected":
                             shapeState = ShapeState.SELECTED;
                             break;
-                        case "Highlight":
+                        case "highlight":
                             shapeState = ShapeState.HIGHLIGHT;
                             break;
-                        case "Invalid":
+                        case "invalid":
                             shapeState = ShapeState.INVALID;
                             break;
                     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -45,6 +45,7 @@ import org.kie.workbench.common.dmn.webapp.kogito.common.client.tour.GuidedTourB
 import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerView;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.LienzoCanvas;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.LienzoPanel;
+import org.kie.workbench.common.stunner.client.lienzo.util.StunnerStateApplier;
 import org.kie.workbench.common.stunner.client.widgets.editor.EditorSessionCommands;
 import org.kie.workbench.common.stunner.client.widgets.editor.StunnerEditor;
 import org.kie.workbench.common.stunner.core.client.ReadOnlyProvider;
@@ -56,7 +57,6 @@ import org.kie.workbench.common.stunner.core.client.components.layout.LayoutHelp
 import org.kie.workbench.common.stunner.core.client.components.layout.OpenDiagramLayoutExecutor;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
-import org.kie.workbench.common.stunner.core.client.shape.ShapeState;
 import org.kie.workbench.common.stunner.core.client.util.WindowJSType;
 import org.kie.workbench.common.stunner.core.documentation.DocumentationView;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
@@ -157,28 +157,10 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
         if (canvas != null) {
             LienzoPanel panel = (LienzoPanel) canvas.getView().getPanel();
             LienzoBoundsPanel lienzoPanel = panel.getView();
-            JsCanvas jsCanvas = new JsCanvas(lienzoPanel, lienzoPanel.getLayer(), (UUID, state) -> {
-                Shape shape = stunnerEditor.getCanvasHandler().getCanvas().getShape(UUID);
-                if (shape != null) {
-                    ShapeState shapeState = null;
-                    switch (state.toLowerCase()) {
-                        case "none":
-                            shapeState = ShapeState.NONE;
-                            break;
-                        case "selected":
-                            shapeState = ShapeState.SELECTED;
-                            break;
-                        case "highlight":
-                            shapeState = ShapeState.HIGHLIGHT;
-                            break;
-                        case "invalid":
-                            shapeState = ShapeState.INVALID;
-                            break;
-                    }
-
-                    if (shapeState != null) {
-                        shape.applyState(shapeState);
-                    }
+            JsCanvas jsCanvas = new JsCanvas(lienzoPanel, lienzoPanel.getLayer(), new StunnerStateApplier() {
+                @Override
+                public Shape getShape(String uuid) {
+                    return stunnerEditor.getCanvasHandler().getCanvas().getShape(uuid);
                 }
             });
             setupJsCanvasTypeNative(jsCanvas);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/util/StunnerStateApplier.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/util/StunnerStateApplier.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.lienzo.util;
+
+import com.ait.lienzo.client.core.types.JSShapeStateApplier;
+import org.kie.workbench.common.stunner.core.client.shape.Shape;
+import org.kie.workbench.common.stunner.core.client.shape.ShapeState;
+
+public abstract class StunnerStateApplier implements JSShapeStateApplier {
+
+    public abstract Shape getShape(String uuid);
+
+    @Override
+    public void applyState(String UUID, String state) {
+
+        Shape shape = getShape(UUID);
+        if (shape != null) {
+            ShapeState shapeState = null;
+            switch (state.toLowerCase()) {
+                case "none":
+                    shapeState = ShapeState.NONE;
+                    break;
+                case "selected":
+                    shapeState = ShapeState.SELECTED;
+                    break;
+                case "highlight":
+                    shapeState = ShapeState.HIGHLIGHT;
+                    break;
+                case "invalid":
+                    shapeState = ShapeState.INVALID;
+                    break;
+            }
+
+            if (shapeState != null) {
+                shape.applyState(shapeState);
+            }
+        }
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/README.md
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/README.md
@@ -94,8 +94,5 @@ It provides buttons for creating new processes, opening an existing process and 
         jsl.getLocation('_A9481DBC-3E87-40EE-9925-733B24404BC0', 'red')         // gets location
         jsl.getAbsoluteLocation('_A9481DBC-3E87-40EE-9925-733B24404BC0', 'red') // gets absolute location
         jsl.getDimensions('_A9481DBC-3E87-40EE-9925-733B24404BC0', 'red')       // gets dimensions
-
-
-
-
-        
+        jsl.applyState('_A9481DBC-3E87-40EE-9925-733B24404BC0', 'invalid')      // applies state (none, highlight, selected, invalid)
+        jsl.centerNode('_A9481DBC-3E87-40EE-9925-733B24404BC0')                 // centers node in viewable canvas

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
@@ -30,6 +30,7 @@ import com.google.gwt.user.client.ui.IsWidget;
 import elemental2.promise.Promise;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.LienzoCanvas;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.LienzoPanel;
+import org.kie.workbench.common.stunner.client.lienzo.util.StunnerStateApplier;
 import org.kie.workbench.common.stunner.client.widgets.editor.EditorSessionCommands;
 import org.kie.workbench.common.stunner.client.widgets.editor.StunnerEditor;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
@@ -42,7 +43,6 @@ import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationServic
 import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
 import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
-import org.kie.workbench.common.stunner.core.client.shape.ShapeState;
 import org.kie.workbench.common.stunner.core.client.util.WindowJSType;
 import org.kie.workbench.common.stunner.core.client.validation.canvas.CanvasDiagramValidator;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
@@ -235,28 +235,10 @@ public class BPMNDiagramEditor {
         if (canvas != null) {
             LienzoPanel panel = (LienzoPanel) canvas.getView().getPanel();
             LienzoBoundsPanel lienzoPanel = panel.getView();
-            JsCanvas jsCanvas = new JsCanvas(lienzoPanel, lienzoPanel.getLayer(), (UUID, state) -> {
-                Shape shape = stunnerEditor.getCanvasHandler().getCanvas().getShape(UUID);
-                if (shape != null) {
-                    ShapeState shapeState = null;
-                    switch (state.toLowerCase()) {
-                        case "none":
-                            shapeState = ShapeState.NONE;
-                            break;
-                        case "selected":
-                            shapeState = ShapeState.SELECTED;
-                            break;
-                        case "highlight":
-                            shapeState = ShapeState.HIGHLIGHT;
-                            break;
-                        case "invalid":
-                            shapeState = ShapeState.INVALID;
-                            break;
-                    }
-
-                    if (shapeState != null) {
-                        shape.applyState(shapeState);
-                    }
+            JsCanvas jsCanvas = new JsCanvas(lienzoPanel, lienzoPanel.getLayer(), new StunnerStateApplier() {
+                @Override
+                public Shape getShape(String uuid) {
+                    return stunnerEditor.getCanvasHandler().getCanvas().getShape(uuid);
                 }
             });
             setupJsCanvasTypeNative(jsCanvas);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
@@ -41,6 +41,8 @@ import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
 import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
+import org.kie.workbench.common.stunner.core.client.shape.Shape;
+import org.kie.workbench.common.stunner.core.client.shape.ShapeState;
 import org.kie.workbench.common.stunner.core.client.util.WindowJSType;
 import org.kie.workbench.common.stunner.core.client.validation.canvas.CanvasDiagramValidator;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
@@ -233,7 +235,30 @@ public class BPMNDiagramEditor {
         if (canvas != null) {
             LienzoPanel panel = (LienzoPanel) canvas.getView().getPanel();
             LienzoBoundsPanel lienzoPanel = panel.getView();
-            JsCanvas jsCanvas = new JsCanvas(lienzoPanel, lienzoPanel.getLayer());
+            JsCanvas jsCanvas = new JsCanvas(lienzoPanel, lienzoPanel.getLayer(), (UUID, state) -> {
+                Shape shape = stunnerEditor.getCanvasHandler().getCanvas().getShape(UUID);
+                if (shape != null) {
+                    ShapeState shapeState = null;
+                    switch (state) {
+                        case "None":
+                            shapeState = ShapeState.NONE;
+                            break;
+                        case "Selected":
+                            shapeState = ShapeState.SELECTED;
+                            break;
+                        case "Highlight":
+                            shapeState = ShapeState.HIGHLIGHT;
+                            break;
+                        case "Invalid":
+                            shapeState = ShapeState.INVALID;
+                            break;
+                    }
+
+                    if (shapeState != null) {
+                        shape.applyState(shapeState);
+                    }
+                }
+            });
             setupJsCanvasTypeNative(jsCanvas);
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
@@ -239,17 +239,17 @@ public class BPMNDiagramEditor {
                 Shape shape = stunnerEditor.getCanvasHandler().getCanvas().getShape(UUID);
                 if (shape != null) {
                     ShapeState shapeState = null;
-                    switch (state) {
-                        case "None":
+                    switch (state.toLowerCase()) {
+                        case "none":
                             shapeState = ShapeState.NONE;
                             break;
-                        case "Selected":
+                        case "selected":
                             shapeState = ShapeState.SELECTED;
                             break;
-                        case "Highlight":
+                        case "highlight":
                             shapeState = ShapeState.HIGHLIGHT;
                             break;
-                        case "Invalid":
+                        case "invalid":
                             shapeState = ShapeState.INVALID;
                             break;
                     }

--- a/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JSShapeStateApplier.java
+++ b/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JSShapeStateApplier.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ait.lienzo.client.core.types;
+
+public interface JSShapeStateApplier {
+
+    void applyState(String UUID, String state);
+}

--- a/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JsCanvas.java
+++ b/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JsCanvas.java
@@ -28,8 +28,8 @@ import com.ait.lienzo.client.core.shape.wires.WiresManager;
 import com.ait.lienzo.client.core.shape.wires.WiresShape;
 import com.ait.lienzo.client.core.shape.wires.types.JsWiresShape;
 import com.ait.lienzo.client.widget.panel.LienzoPanel;
+import com.ait.lienzo.client.widget.panel.impl.ScrollablePanel;
 import com.ait.lienzo.tools.client.collection.NFastArrayList;
-import elemental2.dom.DomGlobal;
 import elemental2.dom.HTMLCanvasElement;
 import jsinterop.annotations.JsType;
 
@@ -38,13 +38,16 @@ public class JsCanvas implements JsCanvasNodeLister {
 
     LienzoPanel panel;
     Layer layer;
+    protected JSShapeStateApplier stateApplier;
+
     public static JsCanvasEvents events;
     public static JsCanvasAnimations animations;
     public static JsCanvasLogger logger;
 
-    public JsCanvas(LienzoPanel panel, Layer layer) {
+    public JsCanvas(LienzoPanel panel, Layer layer, JSShapeStateApplier stateApplier) {
         this.panel = panel;
         this.layer = layer;
+        this.stateApplier = stateApplier;
         this.events = null;
     }
 
@@ -258,6 +261,40 @@ public class JsCanvas implements JsCanvasNodeLister {
             ids.add(shape.getID());
         }
         return ids;
+    }
+
+    public void applyState(String UUID, String state) {
+        stateApplier.applyState(UUID, state);
+    }
+
+    public void center(String UUID) {
+        centerNode(UUID);
+    }
+
+    protected void centerNode(String UUID) {
+        NFastArrayList<Double> absoluteLocation = getAbsoluteLocation(UUID);
+
+        if (absoluteLocation != null) {
+
+            int width = layer.getViewport().getWidth();
+            int height = layer.getViewport().getHeight();
+
+            NFastArrayList<Double> dimensions = getDimensions(UUID);
+            double nodeWidth = 0;
+            double nodeHeight = 0;
+
+            if (dimensions != null) {
+                nodeWidth = dimensions.get(0);
+                nodeHeight = dimensions.get(1);
+            }
+
+            double translatedX = -absoluteLocation.get(0) + (width / 2) - (nodeWidth / 2);
+            double translatedY = -absoluteLocation.get(1) + (height / 2) - (nodeHeight / 2);
+
+            layer.getViewport().getTransform().translate(-layer.getViewport().getTransform().getTranslateX(), -layer.getViewport().getTransform().getTranslateY());
+            layer.getViewport().getTransform().translate(translatedX, translatedY);
+            ((ScrollablePanel) panel).refresh();
+        }
     }
 
     @Override

--- a/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JsCanvas.java
+++ b/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JsCanvas.java
@@ -271,7 +271,7 @@ public class JsCanvas implements JsCanvasNodeLister {
         centerNode(UUID);
     }
 
-    protected void centerNode(String UUID) {
+    public void centerNode(String UUID) {
         NFastArrayList<Double> absoluteLocation = getAbsoluteLocation(UUID);
 
         if (absoluteLocation != null) {

--- a/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JsCanvas.java
+++ b/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JsCanvas.java
@@ -276,8 +276,8 @@ public class JsCanvas implements JsCanvasNodeLister {
 
         if (absoluteLocation != null) {
 
-            int width = layer.getViewport().getWidth();
-            int height = layer.getViewport().getHeight();
+            double width = layer.getViewport().getWidth();
+            double height = layer.getViewport().getHeight();
 
             NFastArrayList<Double> dimensions = getDimensions(UUID);
             double nodeWidth = 0;

--- a/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JsCanvas.java
+++ b/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JsCanvas.java
@@ -291,9 +291,11 @@ public class JsCanvas implements JsCanvasNodeLister {
             double translatedX = -absoluteLocation.get(0) + (width / 2) - (nodeWidth / 2);
             double translatedY = -absoluteLocation.get(1) + (height / 2) - (nodeHeight / 2);
 
-            layer.getViewport().getTransform().translate(-layer.getViewport().getTransform().getTranslateX(), -layer.getViewport().getTransform().getTranslateY());
-            layer.getViewport().getTransform().translate(translatedX, translatedY);
-            ((ScrollablePanel) panel).refresh();
+            if (translatedX <= 0 && translatedY <= 0) { // prevent moving (0,0) Dotten Line right/below
+                layer.getViewport().getTransform().translate(-layer.getViewport().getTransform().getTranslateX(), -layer.getViewport().getTransform().getTranslateY());
+                layer.getViewport().getTransform().translate(translatedX, translatedY);
+                ((ScrollablePanel) panel).refresh();
+            }
         }
     }
 

--- a/lienzo-tests/src/test/java/com/ait/lienzo/client/core/types/JsCanvasTest.java
+++ b/lienzo-tests/src/test/java/com/ait/lienzo/client/core/types/JsCanvasTest.java
@@ -26,8 +26,8 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -39,6 +39,9 @@ public class JsCanvasTest {
 
     @Mock
     private JsWiresShape jsWiresShape;
+
+    @Mock
+    JSShapeStateApplier shapeStateApplier;
 
     @Test
     public void testGetBackgroundColor() {
@@ -213,5 +216,21 @@ public class JsCanvasTest {
         assertEquals(null, dimensions);
         dimensions = jsCanvas.getDimensions("");
         assertEquals(null, dimensions);
+    }
+
+    @Test
+    public void testApplyState() {
+        jsCanvas.stateApplier = shapeStateApplier;
+        doCallRealMethod().when(jsCanvas).applyState(anyString(), anyString());
+
+        jsCanvas.applyState("someId", "None");
+        verify(shapeStateApplier, times(1)).applyState("someId", "None");
+    }
+
+    @Test
+    public void testCenter() {
+        doCallRealMethod().when(jsCanvas).center(anyString());
+        jsCanvas.center("someId");
+        verify(jsCanvas, times(1)).centerNode("someId");
     }
 }

--- a/lienzo-webapp/src/main/java/org/kie/lienzo/client/BaseExample.java
+++ b/lienzo-webapp/src/main/java/org/kie/lienzo/client/BaseExample.java
@@ -71,7 +71,8 @@ public abstract class BaseExample implements Example {
         MousePanMediator pan = new MousePanMediator(EventFilter.META);
         this.panel.getViewport().pushMediator(pan);
 
-        jsCanvas = new JsCanvas(this.panel, this.layer);
+        jsCanvas = new JsCanvas(this.panel, this.layer, (UUID, state) -> {
+           });
         setupJsCanvasTypes(jsCanvas);
     }
 


### PR DESCRIPTION
Hi @romartin @Josephblt  can you review this PR? Builds for BPMN/DMN can be found here. https://drive.google.com/drive/folders/1nAKJbFOfwANOuFACPO78tbkJLRRZRxpd?usp=sharing

How to test
1) Deploy BPMN or DMN
2) Create a Node
3) On Developer console type: 
a) var jsl = window.frames.editorFrame.contentWindow.canvas;
b) jsl.getNodeIds();
c) to test Apply State, type: jsl.applyState("[node id from b step]", "state"), state being "none", "highlight", "selected" or "invalid"
d) to test Center Node type jsl.centerNode("[node id from b step]")

Thanks, let me know

Related PR for Envelope TS exposing is https://github.com/kiegroup/kogito-tooling/pull/703