### PR TITLE
Fix missing sonar reports for PR

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
         }
         stage('Analyze Kogito Editors Java by SonarCloud') {
             when {
-                expression { isNormalPRCheck() && isSonarCloudEnabled() }
+                expression { isNormalPRCheck() }
             }
             steps {
                 script {
@@ -132,10 +132,6 @@ String getUpstreamTriggerProject() {
 
 boolean isNormalPRCheck() {
     return !isDownstreamJob()
-}
-
-boolean isSonarCloudEnabled() {
-    return env['ENABLE_SONARCLOUD'] && env['ENABLE_SONARCLOUD'].toBoolean()
 }
 
 Integer getTimeoutValue() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
@@ -31,6 +31,7 @@
 
   <properties>
     <java.module.name>org.kie.wb.common.dmn.client</java.module.name>
+    <!-- just a comment to test CI -->
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This is afix for skipped sonar check pahes. The bellow comes form current CI log:
```
[Pipeline] { (Analyze Kogito Editors Java by SonarCloud)
Stage "Analyze Kogito Editors Java by SonarCloud" skipped due to when conditional
```

Dependent on https://github.com/kiegroup/kogito-editors-java/pull/184