### PR TITLE
KOGITO-5901: Resolving dependabot alerts

### DIFF
--- a/errai-bom/pom.xml
+++ b/errai-bom/pom.xml
@@ -75,7 +75,6 @@
     <jboss.web.version>7.0.16.Final</jboss.web.version>
     <jsr305.version>1.3.9</jsr305.version>
     <mojo.executor.version>2.2.0</mojo.executor.version>
-    <netty.codec.http.version>4.1.59.Final</netty.codec.http.version>
 
     <sonar.skip>true</sonar.skip>
 
@@ -448,16 +447,6 @@
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
         <version>${asm.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec-http</artifactId>
-        <version>${netty.codec.http.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-handler</artifactId>
-        <version>${netty.codec.http.version}</version>
       </dependency>
       <dependency>
         <groupId>javax</groupId>

--- a/errai-bom/pom.xml
+++ b/errai-bom/pom.xml
@@ -291,11 +291,6 @@
         <version>${version.de.benediktmeurer.gwt-slf4j}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty</artifactId>
-        <version>${version.io.netty}</version>
-      </dependency>
-      <dependency>
         <groupId>javax.enterprise</groupId>
         <artifactId>cdi-api</artifactId>
         <version>${version.javax.enterprise}</version>


### PR DESCRIPTION
`dependabot` reported a vulnerability with a netty dependency here https://github.com/kiegroup/kogito-editors-java/pull/189.
After a check, I noticed no netty dependency is actively used in the project, so we can safely removed it to solve the reported issue.