### PR TITLE
KOGITO-4588: DataType concept in the editor should cover both "custom" and "out-of-the-box" data types

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/ItemDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/ItemDefinition.java
@@ -16,6 +16,7 @@
 package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
@@ -32,6 +33,8 @@ import static java.util.Collections.singletonList;
 @Portable
 public class ItemDefinition extends NamedElement implements HasTypeRef,
                                                             DynamicReadOnly {
+
+    public static final Comparator<ItemDefinition> ITEM_DEFINITION_COMPARATOR = Comparator.comparing(o -> o.getName().getValue());
 
     private QName typeRef;
     private UnaryTests allowedValues;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/types/BuiltInType.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/types/BuiltInType.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.dmn.api.property.dmn.types;
 
+import java.util.Comparator;
+
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public enum BuiltInType {
@@ -34,6 +36,13 @@ public enum BuiltInType {
     DATE("date"),
     CONTEXT("context"),
     UNDEFINED("<Undefined>");
+
+    public static final Comparator<BuiltInType> BUILT_IN_TYPE_COMPARATOR = Comparator.comparing(o -> {
+        if (o == BuiltInType.UNDEFINED) {
+            return "";
+        }
+        return o.getName();
+    });
 
     private final String[] names;
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/types/BuiltInTypeTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/types/BuiltInTypeTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class BuiltInTypeTest {
 
@@ -36,6 +37,16 @@ public class BuiltInTypeTest {
                      typeRef.getLocalPart());
         assertEquals(QName.NULL_NS_URI,
                      typeRef.getNamespaceURI());
+    }
+
+    @Test
+    public void testComparatorUndefinedBeforeOtherTypes() {
+        assertTrue(BuiltInType.BUILT_IN_TYPE_COMPARATOR.compare(BuiltInType.ANY, BuiltInType.UNDEFINED) > 0);
+    }
+
+    @Test
+    public void testComparatorAscendingOrder() {
+        assertTrue(BuiltInType.BUILT_IN_TYPE_COMPARATOR.compare(BuiltInType.ANY, BuiltInType.BOOLEAN) < 0);
     }
 }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/ClearExpressionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/ClearExpressionCommand.java
@@ -22,6 +22,7 @@ import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.ExpressionProps;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 
 public class ClearExpressionCommand extends FillExpressionCommand<ExpressionProps> {
@@ -30,8 +31,9 @@ public class ClearExpressionCommand extends FillExpressionCommand<ExpressionProp
                                   final ExpressionProps expressionProps,
                                   final Event<ExpressionEditorChanged> editorSelectedEvent,
                                   final String nodeUUID,
-                                  final ExpressionEditorView view) {
-        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+                                  final ExpressionEditorView view,
+                                  final ItemDefinitionUtils itemDefinitionUtils) {
+        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, itemDefinitionUtils);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillContextExpressionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillContextExpressionCommand.java
@@ -23,6 +23,7 @@ import org.kie.workbench.common.dmn.api.definition.model.Context;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.ContextProps;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 
 import static org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.util.ExpressionModelFiller.fillContextExpression;
@@ -33,8 +34,9 @@ public class FillContextExpressionCommand extends FillExpressionCommand<ContextP
                                         final ContextProps expressionProps,
                                         final Event<ExpressionEditorChanged> editorSelectedEvent,
                                         final String nodeUUID,
-                                        final ExpressionEditorView view) {
-        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+                                        final ExpressionEditorView view,
+                                        final ItemDefinitionUtils itemDefinitionUtils) {
+        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, itemDefinitionUtils);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillDecisionTableExpressionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillDecisionTableExpressionCommand.java
@@ -23,6 +23,7 @@ import org.kie.workbench.common.dmn.api.definition.model.DecisionTable;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.DecisionTableProps;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 
 import static org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.util.ExpressionModelFiller.fillDecisionTableExpression;
@@ -33,8 +34,9 @@ public class FillDecisionTableExpressionCommand extends FillExpressionCommand<De
                                               final DecisionTableProps expressionProps,
                                               final Event<ExpressionEditorChanged> editorSelectedEvent,
                                               final String nodeUUID,
-                                              final ExpressionEditorView view) {
-        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+                                              final ExpressionEditorView view,
+                                              final ItemDefinitionUtils itemDefinitionUtils) {
+        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, itemDefinitionUtils);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillFunctionExpressionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillFunctionExpressionCommand.java
@@ -23,6 +23,7 @@ import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.FunctionDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.FunctionProps;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 
 import static org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.util.ExpressionModelFiller.fillFunctionExpression;
@@ -33,8 +34,9 @@ public class FillFunctionExpressionCommand extends FillExpressionCommand<Functio
                                          final FunctionProps expressionProps,
                                          final Event<ExpressionEditorChanged> editorSelectedEvent,
                                          final String nodeUUID,
-                                         final ExpressionEditorView view) {
-        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+                                         final ExpressionEditorView view,
+                                         final ItemDefinitionUtils itemDefinitionUtils) {
+        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, itemDefinitionUtils);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillInvocationExpressionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillInvocationExpressionCommand.java
@@ -23,6 +23,7 @@ import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.Invocation;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.InvocationProps;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 
 import static org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.util.ExpressionModelFiller.fillInvocationExpression;
@@ -33,8 +34,9 @@ public class FillInvocationExpressionCommand extends FillExpressionCommand<Invoc
                                            final InvocationProps expressionProps,
                                            final Event<ExpressionEditorChanged> editorSelectedEvent,
                                            final String nodeUUID,
-                                           final ExpressionEditorView view) {
-        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+                                           final ExpressionEditorView view,
+                                           final ItemDefinitionUtils itemDefinitionUtils) {
+        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, itemDefinitionUtils);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillListExpressionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillListExpressionCommand.java
@@ -23,6 +23,7 @@ import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.List;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.ListProps;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 
 import static org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.util.ExpressionModelFiller.fillListExpression;
@@ -33,8 +34,9 @@ public class FillListExpressionCommand extends FillExpressionCommand<ListProps> 
                                      final ListProps expressionProps,
                                      final Event<ExpressionEditorChanged> editorSelectedEvent,
                                      final String nodeUUID,
-                                     final ExpressionEditorView view) {
-        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+                                     final ExpressionEditorView view,
+                                     final ItemDefinitionUtils itemDefinitionUtils) {
+        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, itemDefinitionUtils);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillLiteralExpressionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillLiteralExpressionCommand.java
@@ -23,6 +23,7 @@ import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.LiteralExpression;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.LiteralProps;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 
 import static org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.util.ExpressionModelFiller.fillLiteralExpression;
@@ -33,8 +34,9 @@ public class FillLiteralExpressionCommand extends FillExpressionCommand<LiteralP
                                         final LiteralProps expressionProps,
                                         final Event<ExpressionEditorChanged> editorSelectedEvent,
                                         final String nodeUUID,
-                                        final ExpressionEditorView view) {
-        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+                                        final ExpressionEditorView view,
+                                        final ItemDefinitionUtils itemDefinitionUtils) {
+        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, itemDefinitionUtils);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillRelationExpressionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillRelationExpressionCommand.java
@@ -23,6 +23,7 @@ import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.Relation;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.RelationProps;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 
 import static org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.util.ExpressionModelFiller.fillRelationExpression;
@@ -33,8 +34,9 @@ public class FillRelationExpressionCommand extends FillExpressionCommand<Relatio
                                          final RelationProps expressionProps,
                                          final Event<ExpressionEditorChanged> editorSelectedEvent,
                                          final String nodeUUID,
-                                         final ExpressionEditorView view) {
-        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+                                         final ExpressionEditorView view,
+                                         final ItemDefinitionUtils itemDefinitionUtils) {
+        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, itemDefinitionUtils);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/props/DataTypeProps.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/props/DataTypeProps.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props;
+
+import jsinterop.annotations.JsType;
+
+@JsType
+public class DataTypeProps {
+    public final String typeRef;
+    public final String name;
+    public final Boolean isCustom;
+
+    public DataTypeProps(final String typeRef, final String name, final Boolean isCustom) {
+        this.typeRef = typeRef;
+        this.name = name;
+        this.isCustom = isCustom;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidget.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidget.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.dmn.client.editors.types;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -59,6 +58,9 @@ import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.forms.adf.definitions.DynamicReadOnly;
 import org.kie.workbench.common.stunner.core.client.ReadOnlyProvider;
 
+import static org.kie.workbench.common.dmn.api.definition.model.ItemDefinition.ITEM_DEFINITION_COMPARATOR;
+import static org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType.BUILT_IN_TYPE_COMPARATOR;
+
 @Dependent
 @Templated
 public class DataTypePickerWidget extends Composite implements HasValue<QName>,
@@ -69,15 +71,6 @@ public class DataTypePickerWidget extends Composite implements HasValue<QName>,
     static final String CSS_DISPLAY_NONE = "none";
 
     static final String READ_ONLY_CSS_CLASS = "read-only";
-
-    static final Comparator<BuiltInType> BUILT_IN_TYPE_COMPARATOR = Comparator.comparing(o -> {
-        if (o == BuiltInType.UNDEFINED) {
-            return "";
-        }
-        return o.getName();
-    });
-
-    static final Comparator<ItemDefinition> ITEM_DEFINITION_COMPARATOR = Comparator.comparing(o -> o.getName().getValue());
 
     @DataField
     private Anchor typeButton;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/js/DMNLoader.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/js/DMNLoader.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.client.js;
 
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsType;
+import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.DataTypeProps;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.ExpressionProps;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.PMMLParam;
 
@@ -36,5 +37,5 @@ public class DMNLoader {
      * @param pmmlParams PMML parameters
      */
     @JsMethod(namespace = "__KIE__DMN_LOADER__")
-    public static native void renderBoxedExpressionEditor(final String selector, final String decisionNodeId, final ExpressionProps expressionProps, final Boolean clearSupportedOnRootExpression, final PMMLParam[] pmmlParams);
+    public static native void renderBoxedExpressionEditor(final String selector, final String decisionNodeId, final ExpressionProps expressionProps, final DataTypeProps[] dataTypeProps, final Boolean clearSupportedOnRootExpression, final PMMLParam[] pmmlParams);
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/js/DMNLoader.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/js/DMNLoader.java
@@ -37,5 +37,5 @@ public class DMNLoader {
      * @param pmmlParams PMML parameters
      */
     @JsMethod(namespace = "__KIE__DMN_LOADER__")
-    public static native void renderBoxedExpressionEditor(final String selector, final String decisionNodeId, final ExpressionProps expressionProps, final DataTypeProps[] dataTypeProps, final Boolean clearSupportedOnRootExpression, final PMMLParam[] pmmlParams);
+    public static native void renderBoxedExpressionEditor(final String selector, final String decisionNodeId, final ExpressionProps expressionProps, final DataTypeProps[] dataTypes, final Boolean clearSupportedOnRootExpression, final PMMLParam[] pmmlParams);
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/ClearExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/ClearExpressionCommandTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.ExpressionProps;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.mockito.Mock;
 
@@ -48,6 +49,9 @@ public class ClearExpressionCommandTest {
     @Mock
     private ExpressionEditorView view;
 
+    @Mock
+    private ItemDefinitionUtils itemDefinitionUtils;
+
     private ClearExpressionCommand expressionCommand;
 
     private final String nodeUUID = "node uuid";
@@ -58,7 +62,8 @@ public class ClearExpressionCommandTest {
                                                             expressionProps,
                                                             editorSelectedEvent,
                                                             nodeUUID,
-                                                            view);
+                                                            view,
+                                                            itemDefinitionUtils);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillContextExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillContextExpressionCommandTest.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.dmn.api.definition.model.Context;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.ContextProps;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.mockito.Mock;
 import org.uberfire.mocks.EventSourceMock;
@@ -56,6 +57,9 @@ public class FillContextExpressionCommandTest {
     @Mock
     private Context existingExpression;
 
+    @Mock
+    private ItemDefinitionUtils itemDefinitionUtils;
+
     @Before
     public void setup() {
 
@@ -65,7 +69,8 @@ public class FillContextExpressionCommandTest {
                                                        expressionProps,
                                                        editorSelectedEvent,
                                                        "nodeUUID",
-                                                       view));
+                                                       view,
+                                                       itemDefinitionUtils));
         doNothing().when(command).fill(any(), any());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillDecisionTableExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillDecisionTableExpressionCommandTest.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.dmn.api.definition.model.DecisionTable;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.DecisionTableProps;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.mockito.Mock;
 import org.uberfire.mocks.EventSourceMock;
@@ -56,6 +57,9 @@ public class FillDecisionTableExpressionCommandTest {
     @Mock
     private DecisionTable existingExpression;
 
+    @Mock
+    private ItemDefinitionUtils itemDefinitionUtils;
+
     @Before
     public void setup() {
 
@@ -65,7 +69,8 @@ public class FillDecisionTableExpressionCommandTest {
                                                              expressionProps,
                                                              editorSelectedEvent,
                                                              "nodeUUID",
-                                                             view));
+                                                             view,
+                                                             itemDefinitionUtils));
         doNothing().when(command).fill(any(), any());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillExpressionCommandTest.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
+import java.util.Optional;
+
 import javax.enterprise.event.Event;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -27,6 +29,7 @@ import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.HasVariable;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.InformationItemPrimary;
+import org.kie.workbench.common.dmn.api.definition.model.ItemDefinition;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
@@ -178,6 +181,19 @@ public class FillExpressionCommandTest {
         final QName result = command.getTypeRef("unknown");
 
         assertEquals(BuiltInType.UNDEFINED.asQName(), result);
+    }
+
+    @Test
+    public void testGetTypeRef_WhenIsACustomTypeRef() {
+        final String customName = "custom";
+        final ItemDefinition customItemDefinition = new ItemDefinition();
+        customItemDefinition.setName(new Name(customName));
+
+        when(itemDefinitionUtils.findByName(customName)).thenReturn(Optional.of(customItemDefinition));
+
+        final QName result = command.getTypeRef(customName);
+
+        assertEquals(customName, result.getLocalPart());
     }
 
     class FillExpressionCommandMock extends FillExpressionCommand {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillExpressionCommandTest.java
@@ -32,6 +32,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.ExpressionProps;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
@@ -66,6 +67,9 @@ public class FillExpressionCommandTest {
 
     @Mock
     private Expression existingExpression;
+
+    @Mock
+    private ItemDefinitionUtils itemDefinitionUtils;
 
     private final String nodeUUID = "uuid";
 
@@ -183,7 +187,7 @@ public class FillExpressionCommandTest {
                                          final Event<ExpressionEditorChanged> editorSelectedEvent,
                                          final String nodeUUID,
                                          final ExpressionEditorView view) {
-            super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+            super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, itemDefinitionUtils);
         }
 
         @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillFunctionExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillFunctionExpressionCommandTest.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.FunctionDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.FunctionProps;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.mockito.Mock;
 import org.uberfire.mocks.EventSourceMock;
@@ -56,6 +57,9 @@ public class FillFunctionExpressionCommandTest {
     @Mock
     private FunctionDefinition existingExpression;
 
+    @Mock
+    private ItemDefinitionUtils itemDefinitionUtils;
+
     @Before
     public void setup() {
 
@@ -65,7 +69,8 @@ public class FillFunctionExpressionCommandTest {
                                                         expressionProps,
                                                         editorSelectedEvent,
                                                         "nodeUUID",
-                                                        view));
+                                                        view,
+                                                        itemDefinitionUtils));
         doNothing().when(command).fill(any(), any());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillInvocationExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillInvocationExpressionCommandTest.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.Invocation;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.InvocationProps;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.mockito.Mock;
 import org.uberfire.mocks.EventSourceMock;
@@ -56,6 +57,9 @@ public class FillInvocationExpressionCommandTest {
     @Mock
     private Invocation existingExpression;
 
+    @Mock
+    private ItemDefinitionUtils itemDefinitionUtils;
+
     @Before
     public void setup() {
 
@@ -65,7 +69,8 @@ public class FillInvocationExpressionCommandTest {
                                                           expressionProps,
                                                           editorSelectedEvent,
                                                           "nodeUUID",
-                                                          view));
+                                                          view,
+                                                          itemDefinitionUtils));
         doNothing().when(command).fill(any(), any());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillListExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillListExpressionCommandTest.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.List;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.ListProps;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.mockito.Mock;
 import org.uberfire.mocks.EventSourceMock;
@@ -56,6 +57,9 @@ public class FillListExpressionCommandTest extends TestCase {
     @Mock
     private List existingExpression;
 
+    @Mock
+    private ItemDefinitionUtils itemDefinitionUtils;
+
     @Before
     public void setup() {
 
@@ -65,7 +69,8 @@ public class FillListExpressionCommandTest extends TestCase {
                                                     expressionProps,
                                                     editorSelectedEvent,
                                                     "nodeUUID",
-                                                    view));
+                                                    view,
+                                                    itemDefinitionUtils));
         doNothing().when(command).fill(any(), any());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillLiteralExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillLiteralExpressionCommandTest.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.LiteralExpression;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.LiteralProps;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.mockito.Mock;
 import org.uberfire.mocks.EventSourceMock;
@@ -56,6 +57,9 @@ public class FillLiteralExpressionCommandTest {
     @Mock
     private LiteralExpression existingExpression;
 
+    @Mock
+    private ItemDefinitionUtils itemDefinitionUtils;
+
     @Before
     public void setup() {
 
@@ -65,7 +69,8 @@ public class FillLiteralExpressionCommandTest {
                                                        expressionProps,
                                                        editorSelectedEvent,
                                                        "nodeUUID",
-                                                       view));
+                                                       view,
+                                                       itemDefinitionUtils));
         doNothing().when(command).fill(any(), any());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillRelationExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillRelationExpressionCommandTest.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.Relation;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.RelationProps;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.mockito.Mock;
 import org.uberfire.mocks.EventSourceMock;
@@ -58,6 +59,9 @@ public class FillRelationExpressionCommandTest {
 
     private final String nodeUUID = "nodeUUID";
 
+    @Mock
+    private ItemDefinitionUtils itemDefinitionUtils;
+
     @Before
     public void setup() {
 
@@ -67,7 +71,8 @@ public class FillRelationExpressionCommandTest {
                                                         expressionProps,
                                                         editorSelectedEvent,
                                                         nodeUUID,
-                                                        view));
+                                                        view,
+                                                        itemDefinitionUtils));
         doNothing().when(command).fill(any(), any());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidgetTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidgetTest.java
@@ -58,6 +58,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.api.definition.model.ItemDefinition.ITEM_DEFINITION_COMPARATOR;
 import static org.kie.workbench.common.dmn.client.editors.types.DataTypePickerWidget.READ_ONLY_CSS_CLASS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -213,7 +214,7 @@ public class DataTypePickerWidgetTest {
         assertThat(builtInTypes).hasSameElementsAs(builtInTypesAddedToWidget);
 
         //Check the items were sorted correctly
-        assertTrue(Ordering.from(DataTypePickerWidget.BUILT_IN_TYPE_COMPARATOR).isOrdered(builtInTypesAddedToWidget));
+        assertTrue(Ordering.from(BuiltInType.BUILT_IN_TYPE_COMPARATOR).isOrdered(builtInTypesAddedToWidget));
 
         //First item must be "<Undefined>"
         assertEquals(builtInTypesAddedToWidget.get(0).getName(), BuiltInType.UNDEFINED.getName());
@@ -240,7 +241,7 @@ public class DataTypePickerWidgetTest {
         assertTrue(itemDefinitions.isEmpty());
 
         //Check the items were sorted correctly
-        assertTrue(Ordering.from(DataTypePickerWidget.ITEM_DEFINITION_COMPARATOR).isOrdered(itemDefinitionsAddedToWidget));
+        assertTrue(Ordering.from(ITEM_DEFINITION_COMPARATOR).isOrdered(itemDefinitionsAddedToWidget));
     }
 
     @Test

--- a/kogito-editors-js/packages/boxed-expression-component/showcase/cypress/integration/context_expression_spec.ts
+++ b/kogito-editors-js/packages/boxed-expression-component/showcase/cypress/integration/context_expression_spec.ts
@@ -36,7 +36,7 @@ describe("Context Expression Tests", () => {
       cy.ouiaId("expression-column-1").contains("ContextEntry-1").click();
     });
     cy.ouiaId("edit-expression-data-type").within(($container) => {
-      cy.get("input").click({ force: true });
+      cy.get("span.pf-c-select__toggle-text").click({ force: true });
     });
 
     cy.get("button:contains('boolean')").click({ force: true });

--- a/kogito-editors-js/packages/boxed-expression-component/showcase/cypress/integration/literal_expression_spec.ts
+++ b/kogito-editors-js/packages/boxed-expression-component/showcase/cypress/integration/literal_expression_spec.ts
@@ -16,12 +16,12 @@ describe("Literal Expression Tests", () => {
     cy.get(".literal-expression-header").click();
 
     cy.ouiaId("edit-expression-data-type").within(($container) => {
-      cy.get("input").click({ force: true });
+      cy.get("span.pf-c-select__toggle-text").click({ force: true });
     });
 
     cy.get("button:contains('boolean')").click({ force: true });
 
     // check boolean is now also in grid
-    cy.get(".expression-data-type").contains("boolean").should("be.visible");
+    cy.get(".expression-data-type span").contains("boolean").should("be.visible");
   });
 });

--- a/kogito-editors-js/packages/boxed-expression-component/showcase/src/index.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/showcase/src/index.tsx
@@ -36,6 +36,7 @@ import { Button, Modal } from "@patternfly/react-core";
 import { CopyIcon, PenIcon } from "@patternfly/react-icons";
 import "./lib/components/BoxedExpressionEditor/base-no-reset-wrapped.css";
 import ReactJson from "react-json-view";
+import { dataTypeProps, pmmlParams } from "./lib/__tests__/__mocks__";
 
 export const App: React.FunctionComponent = () => {
   //This definition comes directly from the decision node
@@ -43,48 +44,6 @@ export const App: React.FunctionComponent = () => {
     name: "Expression Name",
     dataType: DataType.Undefined,
   };
-
-  const pmmlParams = [
-    {
-      document: "mining pmml",
-      modelsFromDocument: [
-        {
-          model: "MiningModelSum",
-          parametersFromModel: [
-            { id: "i1", name: "input1", dataType: DataType.Any },
-            { id: "i2", name: "input2", dataType: DataType.Any },
-            { id: "i3", name: "input3", dataType: DataType.Any },
-          ],
-        },
-      ],
-    },
-    {
-      document: "regression pmml",
-      modelsFromDocument: [
-        {
-          model: "RegressionLinear",
-          parametersFromModel: [
-            { id: "i1", name: "i1", dataType: DataType.Number },
-            { id: "i2", name: "i2", dataType: DataType.Number },
-          ],
-        },
-      ],
-    },
-  ];
-
-  const dataTypeProps = [
-    { typeRef: "Undefined", name: "<Undefined>", isCustom: false },
-    { typeRef: "Any", name: "Any", isCustom: false },
-    { typeRef: "Boolean", name: "boolean", isCustom: false },
-    { typeRef: "Context", name: "context", isCustom: false },
-    { typeRef: "Date", name: "date", isCustom: false },
-    { typeRef: "DateTime", name: "date and time", isCustom: false },
-    { typeRef: "DateTimeDuration", name: "days and time duration", isCustom: false },
-    { typeRef: "Number", name: "number", isCustom: false },
-    { typeRef: "String", name: "string", isCustom: false },
-    { typeRef: "Time", name: "time", isCustom: false },
-    { typeRef: "YearsMonthsDuration", name: "years and months duration", isCustom: false },
-  ];
 
   const [expressionDefinition, setExpressionDefinition] = useState(selectedExpression);
 

--- a/kogito-editors-js/packages/boxed-expression-component/showcase/src/index.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/showcase/src/index.tsx
@@ -72,6 +72,20 @@ export const App: React.FunctionComponent = () => {
     },
   ];
 
+  const dataTypeProps = [
+    { typeRef: "Undefined", name: "<Undefined>", isCustom: false },
+    { typeRef: "Any", name: "Any", isCustom: false },
+    { typeRef: "Boolean", name: "boolean", isCustom: false },
+    { typeRef: "Context", name: "context", isCustom: false },
+    { typeRef: "Date", name: "date", isCustom: false },
+    { typeRef: "DateTime", name: "date and time", isCustom: false },
+    { typeRef: "DateTimeDuration", name: "days and time duration", isCustom: false },
+    { typeRef: "Number", name: "number", isCustom: false },
+    { typeRef: "String", name: "string", isCustom: false },
+    { typeRef: "Time", name: "time", isCustom: false },
+    { typeRef: "YearsMonthsDuration", name: "years and months duration", isCustom: false },
+  ];
+
   const [expressionDefinition, setExpressionDefinition] = useState(selectedExpression);
 
   const [typedExpressionDefinition, setTypedExpressionDefinition] = useState(JSON.stringify(selectedExpression));
@@ -129,6 +143,7 @@ export const App: React.FunctionComponent = () => {
         <BoxedExpressionEditor
           decisionNodeId="_00000000-0000-0000-0000-000000000000"
           expressionDefinition={expressionDefinition}
+          dataTypeProps={dataTypeProps}
           pmmlParams={pmmlParams}
         />
       </div>

--- a/kogito-editors-js/packages/boxed-expression-component/showcase/src/index.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/showcase/src/index.tsx
@@ -36,7 +36,7 @@ import { Button, Modal } from "@patternfly/react-core";
 import { CopyIcon, PenIcon } from "@patternfly/react-icons";
 import "./lib/components/BoxedExpressionEditor/base-no-reset-wrapped.css";
 import ReactJson from "react-json-view";
-import { dataTypeProps, pmmlParams } from "./lib/__tests__/__mocks__";
+import { dataTypes, pmmlParams } from "./lib/__tests__/__mocks__";
 
 export const App: React.FunctionComponent = () => {
   //This definition comes directly from the decision node
@@ -102,7 +102,7 @@ export const App: React.FunctionComponent = () => {
         <BoxedExpressionEditor
           decisionNodeId="_00000000-0000-0000-0000-000000000000"
           expressionDefinition={expressionDefinition}
-          dataTypeProps={dataTypeProps}
+          dataTypes={dataTypes}
           pmmlParams={pmmlParams}
         />
       </div>

--- a/kogito-editors-js/packages/boxed-expression-component/src/__tests__/__mocks__/index.ts
+++ b/kogito-editors-js/packages/boxed-expression-component/src/__tests__/__mocks__/index.ts
@@ -17,7 +17,8 @@
 import { DataType } from "../../api";
 
 /**
- * The constant below contains all built-in types currently supported by the Boxed Expression Editor
+ * The constant below contains all built-in types currently supported by the Boxed Expression Editor,
+ * Plus a custom defined data-type.
  * These values are used for testing purpose, and by the showcase
  */
 export const dataTypeProps = [

--- a/kogito-editors-js/packages/boxed-expression-component/src/__tests__/__mocks__/index.ts
+++ b/kogito-editors-js/packages/boxed-expression-component/src/__tests__/__mocks__/index.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DataType } from "../../api";
+
+/**
+ * The constant below contains all built-in types currently supported by the Boxed Expression Editor
+ * These values are used for testing purpose, and by the showcase
+ */
+export const dataTypeProps = [
+  { typeRef: "Undefined", name: "<Undefined>", isCustom: false },
+  { typeRef: "Any", name: "Any", isCustom: false },
+  { typeRef: "Boolean", name: "boolean", isCustom: false },
+  { typeRef: "Context", name: "context", isCustom: false },
+  { typeRef: "Date", name: "date", isCustom: false },
+  { typeRef: "DateTime", name: "date and time", isCustom: false },
+  { typeRef: "DateTimeDuration", name: "days and time duration", isCustom: false },
+  { typeRef: "Number", name: "number", isCustom: false },
+  { typeRef: "String", name: "string", isCustom: false },
+  { typeRef: "Time", name: "time", isCustom: false },
+  { typeRef: "YearsMonthsDuration", name: "years and months duration", isCustom: false },
+];
+
+/**
+ * The constant below contains an example of PMML params to be used for testing purpose, and by the showcase
+ */
+export const pmmlParams = [
+  {
+    document: "document",
+    modelsFromDocument: [
+      { model: "model", parametersFromModel: [{ id: "p1", name: "p-1", dataType: DataType.Number }] },
+    ],
+  },
+  {
+    document: "mining pmml",
+    modelsFromDocument: [
+      {
+        model: "MiningModelSum",
+        parametersFromModel: [
+          { id: "i1", name: "input1", dataType: DataType.Any },
+          { id: "i2", name: "input2", dataType: DataType.Any },
+          { id: "i3", name: "input3", dataType: DataType.Any },
+        ],
+      },
+    ],
+  },
+  {
+    document: "regression pmml",
+    modelsFromDocument: [
+      {
+        model: "RegressionLinear",
+        parametersFromModel: [
+          { id: "i1", name: "i1", dataType: DataType.Number },
+          { id: "i2", name: "i2", dataType: DataType.Number },
+        ],
+      },
+    ],
+  },
+];

--- a/kogito-editors-js/packages/boxed-expression-component/src/__tests__/__mocks__/index.ts
+++ b/kogito-editors-js/packages/boxed-expression-component/src/__tests__/__mocks__/index.ts
@@ -32,6 +32,7 @@ export const dataTypeProps = [
   { typeRef: "String", name: "string", isCustom: false },
   { typeRef: "Time", name: "time", isCustom: false },
   { typeRef: "YearsMonthsDuration", name: "years and months duration", isCustom: false },
+  { typeRef: "tPerson", name: "tPerson", isCustom: true },
 ];
 
 /**

--- a/kogito-editors-js/packages/boxed-expression-component/src/__tests__/__mocks__/index.ts
+++ b/kogito-editors-js/packages/boxed-expression-component/src/__tests__/__mocks__/index.ts
@@ -21,7 +21,7 @@ import { DataType } from "../../api";
  * Plus a custom defined data-type.
  * These values are used for testing purpose, and by the showcase
  */
-export const dataTypeProps = [
+export const dataTypes = [
   { typeRef: "Undefined", name: "<Undefined>", isCustom: false },
   { typeRef: "Any", name: "Any", isCustom: false },
   { typeRef: "Boolean", name: "boolean", isCustom: false },

--- a/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/BoxedExpressionEditor/BoxedExpressionEditor.test.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/BoxedExpressionEditor/BoxedExpressionEditor.test.tsx
@@ -27,6 +27,7 @@ describe("BoxedExpressionEditor tests", () => {
       <BoxedExpressionEditor
         decisionNodeId="_00000000-0000-0000-0000-000000000000"
         expressionDefinition={selectedExpression}
+        dataTypeProps={[{ typeRef: "ANY", name: "Any", isCustom: false }]}
       />
     );
 

--- a/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/BoxedExpressionEditor/BoxedExpressionEditor.test.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/BoxedExpressionEditor/BoxedExpressionEditor.test.tsx
@@ -27,7 +27,7 @@ describe("BoxedExpressionEditor tests", () => {
       <BoxedExpressionEditor
         decisionNodeId="_00000000-0000-0000-0000-000000000000"
         expressionDefinition={selectedExpression}
-        dataTypeProps={[{ typeRef: "ANY", name: "Any", isCustom: false }]}
+        dataTypes={[{ typeRef: "ANY", name: "Any", isCustom: false }]}
       />
     );
 

--- a/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/EditExpressionMenu/EditExpressionMenu.test.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/EditExpressionMenu/EditExpressionMenu.test.tsx
@@ -15,12 +15,13 @@
  */
 
 import { fireEvent, render } from "@testing-library/react";
-import { usingTestingBoxedExpressionI18nContext } from "../test-utils";
+import { usingTestingBoxedExpressionI18nContext, usingTestingBoxedExpressionProviderContext } from "../test-utils";
 import * as React from "react";
 import { EditExpressionMenu } from "../../../components/EditExpressionMenu";
 import { activatePopover } from "../PopoverMenu/PopoverMenu.test";
 import { DataType, ExpressionProps, LogicType } from "../../../api";
 import * as _ from "lodash";
+import { act } from "react-dom/test-utils";
 
 jest.useFakeTimers();
 
@@ -205,5 +206,34 @@ describe("EditExpressionMenu tests", () => {
       name: "changed",
       dataType: DataType.Undefined,
     });
+  });
+
+  test("should filter the list of data types when user search for it", async () => {
+    const booleanDataType = "boolean";
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        usingTestingBoxedExpressionProviderContext(
+          <div>
+            <div id="container">Popover</div>
+            <EditExpressionMenu
+              selectedExpressionName="init"
+              arrowPlacement={() => document.getElementById("container")!}
+              appendTo={() => document.getElementById("container")!}
+              onExpressionUpdate={_.identity}
+            />
+          </div>
+        ).wrapper
+      ).wrapper
+    );
+
+    await activatePopover(container as HTMLElement);
+    await act(async () => {
+      fireEvent.click(container.querySelector("[id^='pf-select-toggle-id-'] span")! as HTMLSpanElement);
+    });
+    const input = container.querySelector("div.pf-c-select__menu-search input.pf-c-form-control") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: booleanDataType } });
+
+    expect(container.querySelectorAll(".pf-c-select__menu button")).toHaveLength(1);
+    expect(container.querySelectorAll(".pf-c-select__menu button")[0]).toHaveTextContent(booleanDataType);
   });
 });

--- a/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/EditExpressionMenu/EditExpressionMenu.test.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/EditExpressionMenu/EditExpressionMenu.test.tsx
@@ -120,7 +120,7 @@ describe("EditExpressionMenu tests", () => {
     await activatePopover(container as HTMLElement);
 
     expect(container.querySelector("[id^='pf-select-toggle-id-']")).toBeTruthy();
-    expect((container.querySelector("[id^='pf-select-toggle-id-']")! as HTMLInputElement).value).toBe(
+    expect((container.querySelector("[id^='pf-select-toggle-id-'] span")! as HTMLSpanElement).textContent).toBe(
       LogicType.Undefined
     );
   });
@@ -147,7 +147,9 @@ describe("EditExpressionMenu tests", () => {
     await activatePopover(container as HTMLElement);
 
     expect(container.querySelector("[id^='pf-select-toggle-id-']")).toBeTruthy();
-    expect((container.querySelector("[id^='pf-select-toggle-id-']")! as HTMLInputElement).value).toBe(selectedDataType);
+    expect((container.querySelector("[id^='pf-select-toggle-id-'] span")! as HTMLSpanElement).textContent).toBe(
+      selectedDataType
+    );
   });
 
   test("should render passed expression name, when it is pre-selected", async () => {

--- a/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/FunctionExpression/FunctionExpression.test.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/FunctionExpression/FunctionExpression.test.tsx
@@ -136,7 +136,9 @@ describe("FunctionExpression tests", () => {
 
       expect(baseElement.querySelectorAll(".parameters-editor .parameters-container .parameter-entry")).toHaveLength(1);
       expect((baseElement.querySelector(".parameter-name") as HTMLInputElement).value).toBe(paramName);
-      expect((baseElement.querySelector(EDIT_EXPRESSION_DATA_TYPE)! as HTMLInputElement).value).toBe(paramDataType);
+      expect((baseElement.querySelector(EDIT_EXPRESSION_DATA_TYPE)! as HTMLSpanElement).textContent).toBe(
+        paramDataType
+      );
     });
 
     test("should update the parameter name, when it gets changed by the user", async () => {

--- a/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/Table/Table.test.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/Table/Table.test.tsx
@@ -18,7 +18,7 @@ import { fireEvent, render } from "@testing-library/react";
 import * as _ from "lodash";
 import * as React from "react";
 import { act } from "react-dom/test-utils";
-import { Column, ColumnInstance, DataRecord } from "react-table";
+import { ColumnInstance, DataRecord } from "react-table";
 import { PASTE_OPERATION } from "../../../components/Table/common";
 import { ColumnsUpdateArgs, DataType, RowsUpdateArgs, TableHandlerConfiguration, TableOperation } from "../../../api";
 import { Table } from "../../../components";
@@ -224,7 +224,9 @@ describe("Table tests", () => {
       expect(baseElement.querySelector(EXPRESSION_POPOVER_MENU)).toBeTruthy();
       expect(baseElement.querySelector(EXPRESSION_POPOVER_MENU_TITLE)?.innerHTML).toBe(editRelationLabel);
       expect((baseElement.querySelector(EDIT_EXPRESSION_NAME)! as HTMLInputElement).value).toBe(columnName);
-      expect((baseElement.querySelector(EDIT_EXPRESSION_DATA_TYPE)! as HTMLInputElement).value).toBe(DataType.Boolean);
+      expect((baseElement.querySelector(EDIT_EXPRESSION_DATA_TYPE)! as HTMLSpanElement).textContent).toBe(
+        DataType.Boolean
+      );
     });
 
     test("should trigger onColumnUpdate, when changing column name via popover", async () => {

--- a/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/test-utils.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/test-utils.tsx
@@ -31,7 +31,7 @@ import { dataTypes, pmmlParams } from "../__mocks__";
 global.console = { ...global.console, warn: jest.fn() };
 
 export const EDIT_EXPRESSION_NAME = "[data-ouia-component-id='edit-expression-name']";
-export const EDIT_EXPRESSION_DATA_TYPE = "[data-ouia-component-id='edit-expression-data-type'] input";
+export const EDIT_EXPRESSION_DATA_TYPE = "[data-ouia-component-id='edit-expression-data-type'] span";
 
 export const flushPromises: () => Promise<unknown> = () => new Promise((resolve) => process.nextTick(resolve));
 

--- a/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/test-utils.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/test-utils.tsx
@@ -26,7 +26,7 @@ import { act } from "react-dom/test-utils";
 import { fireEvent } from "@testing-library/react";
 import { BoxedExpressionGlobalContext } from "../../context";
 import { BoxedExpressionProvider, BoxedExpressionProviderProps } from "../../components";
-import { dataTypeProps, pmmlParams } from "../__mocks__";
+import { dataTypes, pmmlParams } from "../__mocks__";
 
 global.console = { ...global.console, warn: jest.fn() };
 
@@ -64,7 +64,7 @@ export function usingTestingBoxedExpressionProviderContext(
   const usedCtx: BoxedExpressionProviderProps = {
     decisionNodeId: "_00000000-0000-0000-0000-000000000000",
     expressionDefinition: {},
-    dataTypeProps,
+    dataTypes,
     pmmlParams,
     isRunnerTable: false,
     children,
@@ -76,7 +76,7 @@ export function usingTestingBoxedExpressionProviderContext(
       <BoxedExpressionProvider
         decisionNodeId={usedCtx.decisionNodeId}
         expressionDefinition={usedCtx.expressionDefinition}
-        dataTypeProps={usedCtx.dataTypeProps}
+        dataTypes={usedCtx.dataTypes}
         pmmlParams={usedCtx.pmmlParams}
         isRunnerTable={false}
       >
@@ -91,7 +91,7 @@ export function wrapComponentInContext(component: JSX.Element): JSX.Element {
     <BoxedExpressionGlobalContext.Provider
       value={{
         decisionNodeId: "_00000000-0000-0000-0000-000000000000",
-        dataTypeProps,
+        dataTypes: dataTypes,
         pmmlParams,
         supervisorHash: "",
         setSupervisorHash: jest.fn,

--- a/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/test-utils.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/__tests__/components/test-utils.tsx
@@ -25,8 +25,8 @@ import {
 import { act } from "react-dom/test-utils";
 import { fireEvent } from "@testing-library/react";
 import { BoxedExpressionGlobalContext } from "../../context";
-import { DataType } from "../../api";
 import { BoxedExpressionProvider, BoxedExpressionProviderProps } from "../../components";
+import { dataTypeProps, pmmlParams } from "../__mocks__";
 
 global.console = { ...global.console, warn: jest.fn() };
 
@@ -64,14 +64,8 @@ export function usingTestingBoxedExpressionProviderContext(
   const usedCtx: BoxedExpressionProviderProps = {
     decisionNodeId: "_00000000-0000-0000-0000-000000000000",
     expressionDefinition: {},
-    pmmlParams: [
-      {
-        document: "document",
-        modelsFromDocument: [
-          { model: "model", parametersFromModel: [{ id: "p1", name: "p-1", dataType: DataType.Number }] },
-        ],
-      },
-    ],
+    dataTypeProps,
+    pmmlParams,
     isRunnerTable: false,
     children,
     ...ctx,
@@ -82,6 +76,7 @@ export function usingTestingBoxedExpressionProviderContext(
       <BoxedExpressionProvider
         decisionNodeId={usedCtx.decisionNodeId}
         expressionDefinition={usedCtx.expressionDefinition}
+        dataTypeProps={usedCtx.dataTypeProps}
         pmmlParams={usedCtx.pmmlParams}
         isRunnerTable={false}
       >
@@ -96,14 +91,8 @@ export function wrapComponentInContext(component: JSX.Element): JSX.Element {
     <BoxedExpressionGlobalContext.Provider
       value={{
         decisionNodeId: "_00000000-0000-0000-0000-000000000000",
-        pmmlParams: [
-          {
-            document: "document",
-            modelsFromDocument: [
-              { model: "model", parametersFromModel: [{ id: "p1", name: "p-1", dataType: DataType.Number }] },
-            ],
-          },
-        ],
+        dataTypeProps,
+        pmmlParams,
         supervisorHash: "",
         setSupervisorHash: jest.fn,
         editorRef: { current: document.body as HTMLDivElement },

--- a/kogito-editors-js/packages/boxed-expression-component/src/api/DataTypeProps.ts
+++ b/kogito-editors-js/packages/boxed-expression-component/src/api/DataTypeProps.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 
-export * from "./BoxedExpressionEditor";
-export * from "./BuiltinAggregation";
-export * from "./ContextEntry";
-export * from "./DataType";
-export * from "./DataTypeProps";
-export * from "./DecisionTableRule";
-export * from "./EnumUtils";
-export * from "./ExpressionProps";
-export * from "./FunctionKind";
-export * from "./HitPolicy";
-export * from "./LogicType";
-export * from "./Table";
+export interface DataTypeProps {
+  /** Identifier of the data type, e.g. UNDEFINED */
+  typeRef: string;
+  /** Label used for the data type, e.g. <Undefined> */
+  name: string;
+  /** Tells whether this data type is custom or built-in */
+  isCustom: boolean;
+}

--- a/kogito-editors-js/packages/boxed-expression-component/src/api/DataTypeProps.ts
+++ b/kogito-editors-js/packages/boxed-expression-component/src/api/DataTypeProps.ts
@@ -15,7 +15,7 @@
  */
 
 export interface DataTypeProps {
-  /** Identifier of the data type, e.g. UNDEFINED */
+  /** Type reference of the data type, e.g. UNDEFINED */
   typeRef: string;
   /** Label used for the data type, e.g. <Undefined> */
   name: string;

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
@@ -34,7 +34,7 @@ export interface BoxedExpressionEditorProps {
   /** All expression properties used to define it */
   expressionDefinition: ExpressionProps;
   /** The data type elements that can be used in the editor */
-  dataTypeProps: DataTypeProps[];
+  dataTypes: DataTypeProps[];
   /**
    * A boolean used for making (or not) the clear button available on the root expression
    * Note that this parameter will be used only for the root expression.
@@ -80,7 +80,7 @@ export function BoxedExpressionEditor(props: BoxedExpressionEditorProps) {
       <BoxedExpressionProvider
         decisionNodeId={props.decisionNodeId}
         expressionDefinition={expressionDefinition}
-        dataTypeProps={props.dataTypeProps}
+        dataTypes={props.dataTypes}
         pmmlParams={props.pmmlParams}
         isRunnerTable={false}
       >

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
@@ -57,8 +57,6 @@ export function BoxedExpressionEditor(props: BoxedExpressionEditorProps) {
     noClearAction: props.clearSupportedOnRootExpression === false,
   });
 
-  console.log(props.dataTypeProps);
-
   useEffect(() => {
     setExpressionDefinition({
       ...props.expressionDefinition,
@@ -82,6 +80,7 @@ export function BoxedExpressionEditor(props: BoxedExpressionEditorProps) {
       <BoxedExpressionProvider
         decisionNodeId={props.decisionNodeId}
         expressionDefinition={expressionDefinition}
+        dataTypeProps={props.dataTypeProps}
         pmmlParams={props.pmmlParams}
         isRunnerTable={false}
       >

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
@@ -17,7 +17,7 @@
 import { I18nDictionariesProvider } from "@kogito-tooling/i18n/dist/react-components";
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { ExpressionProps, PMMLParams } from "../../api";
+import { DataTypeProps, ExpressionProps, PMMLParams } from "../../api";
 import {
   boxedExpressionEditorDictionaries,
   BoxedExpressionEditorI18nContext,
@@ -33,6 +33,8 @@ export interface BoxedExpressionEditorProps {
   decisionNodeId: string;
   /** All expression properties used to define it */
   expressionDefinition: ExpressionProps;
+  /** The data type elements that can be used in the editor */
+  dataTypeProps: DataTypeProps[];
   /**
    * A boolean used for making (or not) the clear button available on the root expression
    * Note that this parameter will be used only for the root expression.
@@ -54,6 +56,8 @@ export function BoxedExpressionEditor(props: BoxedExpressionEditorProps) {
     ...props.expressionDefinition,
     noClearAction: props.clearSupportedOnRootExpression === false,
   });
+
+  console.log(props.dataTypeProps);
 
   useEffect(() => {
     setExpressionDefinition({

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/BoxedExpressionEditor/BoxedExpressionProvider.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/BoxedExpressionEditor/BoxedExpressionProvider.tsx
@@ -43,7 +43,7 @@ export function BoxedExpressionProvider(props: BoxedExpressionProviderProps) {
     <BoxedExpressionGlobalContext.Provider
       value={{
         decisionNodeId: props.decisionNodeId,
-        dataTypeProps: props.dataTypeProps,
+        dataTypes: props.dataTypes,
         pmmlParams: props.pmmlParams,
         supervisorHash,
         setSupervisorHash,

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/BoxedExpressionEditor/BoxedExpressionProvider.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/BoxedExpressionEditor/BoxedExpressionProvider.tsx
@@ -20,16 +20,10 @@ import "./BoxedExpressionProvider.css";
 import { hashfy, ResizerSupervisor } from "../Resizer";
 import { BoxedExpressionGlobalContext } from "../../context";
 import * as _ from "lodash";
-import { ExpressionProps, PMMLParams } from "../../api";
 import { CellSelectionBox } from "../SelectionBox";
+import { BoxedExpressionEditorProps } from "./BoxedExpressionEditor";
 
-export interface BoxedExpressionProviderProps {
-  /** Identifier of the decision node, where the expression will be hold */
-  decisionNodeId: string;
-  /** All expression properties used to define it */
-  expressionDefinition: ExpressionProps;
-  /** PMML parameters */
-  pmmlParams?: PMMLParams;
+export interface BoxedExpressionProviderProps extends BoxedExpressionEditorProps {
   /** Flag that changes how the resize works when being used by the DMN Runner **/
   isRunnerTable: boolean;
   /** Children component **/
@@ -49,6 +43,7 @@ export function BoxedExpressionProvider(props: BoxedExpressionProviderProps) {
     <BoxedExpressionGlobalContext.Provider
       value={{
         decisionNodeId: props.decisionNodeId,
+        dataTypeProps: props.dataTypeProps,
         pmmlParams: props.pmmlParams,
         supervisorHash,
         setSupervisorHash,

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
@@ -16,11 +16,11 @@
 
 import { Divider, Select, SelectGroup, SelectOption, SelectVariant } from "@patternfly/react-core";
 import * as React from "react";
-import { useCallback, useContext, useState } from "react";
+import { useCallback, useState } from "react";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import * as _ from "lodash";
 import { DataType, DataTypeProps } from "../../api";
-import { BoxedExpressionGlobalContext } from "../../context";
+import { useBoxedExpression } from "../../context";
 
 export interface DataTypeSelectorProps {
   /** The pre-selected data type */
@@ -38,7 +38,7 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
 }) => {
   const { i18n } = useBoxedExpressionEditorI18n();
 
-  const { dataTypes } = useContext(BoxedExpressionGlobalContext);
+  const { dataTypes } = useBoxedExpression();
 
   const [dataTypeSelectOpen, setDataTypeSelectOpen] = useState(false);
 

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
@@ -111,7 +111,7 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
       isGrouped
       hasInlineFilter
       inlineFilterPlaceholderText={i18n.choose}
-      maxHeight={350}
+      maxHeight={500}
     >
       {getDataTypes()}
     </Select>

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
@@ -65,12 +65,11 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
 
   const getDataTypes = useCallback(() => {
     const [customDataTypes, defaultDataTypes] = _.chain(dataTypes).partition("isCustom").value();
-    const dataTypeGroups = [];
+    const dataTypeGroups = [buildOptionsByGroup("default", defaultDataTypes)];
     if (!_.isEmpty(customDataTypes)) {
-      dataTypeGroups.push(buildOptionsByGroup("custom", customDataTypes));
       dataTypeGroups.push(<Divider key="divider" />);
+      dataTypeGroups.push(buildOptionsByGroup("custom", customDataTypes));
     }
-    dataTypeGroups.push(buildOptionsByGroup("default", defaultDataTypes));
     return dataTypeGroups;
   }, [buildOptionsByGroup, dataTypes]);
 

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
@@ -16,10 +16,11 @@
 
 import { Select, SelectOption, SelectVariant } from "@patternfly/react-core";
 import * as React from "react";
-import { useCallback, useState } from "react";
+import { useCallback, useContext, useState } from "react";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import * as _ from "lodash";
 import { DataType } from "../../api";
+import { BoxedExpressionGlobalContext } from "../../context";
 
 export interface DataTypeSelectorProps {
   /** The pre-selected data type */
@@ -37,6 +38,8 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
 }) => {
   const { i18n } = useBoxedExpressionEditorI18n();
 
+  const { dataTypeProps } = useContext(BoxedExpressionGlobalContext);
+
   const [dataTypeSelectOpen, setDataTypeSelectOpen] = useState(false);
 
   const onDataTypeSelect = useCallback(
@@ -48,12 +51,14 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
   );
 
   const getDataTypes = useCallback(() => {
-    return _.map(Object.values(DataType), (key) => (
-      <SelectOption key={key} value={key} data-ouia-component-id={key}>
-        {key}
-      </SelectOption>
-    ));
-  }, []);
+    return _.chain(dataTypeProps)
+      .map(({ name }) => (
+        <SelectOption key={name} value={name} data-ouia-component-id={name}>
+          {name}
+        </SelectOption>
+      ))
+      .value();
+  }, [dataTypeProps]);
 
   const onDataTypeFilter = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
@@ -65,11 +65,12 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
 
   const getDataTypes = useCallback(() => {
     const [customDataTypes, defaultDataTypes] = _.chain(dataTypes).partition("isCustom").value();
-    const dataTypeGroups = [buildOptionsByGroup("default", defaultDataTypes)];
+    const dataTypeGroups = [];
     if (!_.isEmpty(customDataTypes)) {
-      dataTypeGroups.push(<Divider key="divider" />);
       dataTypeGroups.push(buildOptionsByGroup("custom", customDataTypes));
+      dataTypeGroups.push(<Divider key="divider" />);
     }
+    dataTypeGroups.push(buildOptionsByGroup("default", defaultDataTypes));
     return dataTypeGroups;
   }, [buildOptionsByGroup, dataTypes]);
 

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
@@ -38,7 +38,7 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
 }) => {
   const { i18n } = useBoxedExpressionEditorI18n();
 
-  const { dataTypeProps } = useContext(BoxedExpressionGlobalContext);
+  const { dataTypes } = useContext(BoxedExpressionGlobalContext);
 
   const [dataTypeSelectOpen, setDataTypeSelectOpen] = useState(false);
 
@@ -64,7 +64,7 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
   );
 
   const getDataTypes = useCallback(() => {
-    const [customDataTypes, defaultDataTypes] = _.chain(dataTypeProps).partition("isCustom").value();
+    const [customDataTypes, defaultDataTypes] = _.chain(dataTypes).partition("isCustom").value();
     const defaultDataTypeOptions = buildOptionsByGroup("default", defaultDataTypes);
     const dataTypeGroups = [defaultDataTypeOptions];
     const customDataTypeOptions = buildOptionsByGroup("custom", customDataTypes);
@@ -73,7 +73,7 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
       dataTypeGroups.push(customDataTypeOptions);
     }
     return dataTypeGroups;
-  }, [buildOptionsByGroup, dataTypeProps]);
+  }, [buildOptionsByGroup, dataTypes]);
 
   const onFilteringDataTypes = useCallback(
     (_, textInput: string) => {

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
@@ -78,16 +78,17 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
       if (textInput === "") {
         return getDataTypes();
       } else {
-        return getDataTypes()
-          .map((group) => {
-            const filteredGroup = React.cloneElement(group, {
-              children: group?.props?.children?.filter((item: React.ReactElement) => {
-                return item.props.value.toLowerCase().includes(textInput.toLowerCase());
-              }),
-            });
-            if (filteredGroup?.props?.children?.length > 0) return filteredGroup;
-          })
-          .filter(Boolean) as JSX.Element[];
+        return getDataTypes().reduce((groups: JSX.Element[], group: JSX.Element) => {
+          const filteredGroup = React.cloneElement(group, {
+            children: group.props?.children?.filter((item: React.ReactElement) => {
+              return item.props.value.toLowerCase().includes(textInput.toLowerCase());
+            }),
+          });
+          if (filteredGroup && filteredGroup.props?.children?.length > 0) {
+            groups.push(filteredGroup);
+          }
+          return groups;
+        }, []);
       }
     },
     [getDataTypes]

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
@@ -65,12 +65,10 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
 
   const getDataTypes = useCallback(() => {
     const [customDataTypes, defaultDataTypes] = _.chain(dataTypes).partition("isCustom").value();
-    const defaultDataTypeOptions = buildOptionsByGroup("default", defaultDataTypes);
-    const dataTypeGroups = [defaultDataTypeOptions];
-    const customDataTypeOptions = buildOptionsByGroup("custom", customDataTypes);
+    const dataTypeGroups = [buildOptionsByGroup("default", defaultDataTypes)];
     if (!_.isEmpty(customDataTypes)) {
       dataTypeGroups.push(<Divider key="divider" />);
-      dataTypeGroups.push(customDataTypeOptions);
+      dataTypeGroups.push(buildOptionsByGroup("custom", customDataTypes));
     }
     return dataTypeGroups;
   }, [buildOptionsByGroup, dataTypes]);

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
@@ -100,7 +100,7 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
     <Select
       menuAppendTo={menuAppendTo}
       ouiaId="edit-expression-data-type"
-      variant={SelectVariant.typeahead}
+      variant={SelectVariant.single}
       typeAheadAriaLabel={i18n.choose}
       onToggle={onDataTypeSelectToggle}
       onSelect={onDataTypeSelect}

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/EditExpressionMenu/DataTypeSelector.tsx
@@ -111,6 +111,7 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
       isGrouped
       hasInlineFilter
       inlineFilterPlaceholderText={i18n.choose}
+      maxHeight={350}
     >
       {getDataTypes()}
     </Select>

--- a/kogito-editors-js/packages/boxed-expression-component/src/components/InvocationExpression/InvocationExpression.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/components/InvocationExpression/InvocationExpression.tsx
@@ -117,7 +117,7 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = (i
       }
       spreadInvocationExpressionDefinition({ invokedFunction: event.target.value });
     },
-    [spreadInvocationExpressionDefinition]
+    [spreadInvocationExpressionDefinition, invocationProps.invokedFunction]
   );
 
   const headerCellElement = useMemo(

--- a/kogito-editors-js/packages/boxed-expression-component/src/context/BoxedExpressionGlobalContext.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/context/BoxedExpressionGlobalContext.tsx
@@ -28,7 +28,7 @@ export interface BoxedExpressionGlobalContextProps {
   currentlyOpenedHandlerCallback: React.Dispatch<React.SetStateAction<boolean>>;
   setCurrentlyOpenedHandlerCallback: React.Dispatch<
     React.SetStateAction<React.Dispatch<React.SetStateAction<boolean>>>
-    >;
+  >;
 }
 
 export const BoxedExpressionGlobalContext = React.createContext<BoxedExpressionGlobalContextProps>(

--- a/kogito-editors-js/packages/boxed-expression-component/src/context/BoxedExpressionGlobalContext.tsx
+++ b/kogito-editors-js/packages/boxed-expression-component/src/context/BoxedExpressionGlobalContext.tsx
@@ -15,19 +15,20 @@
  */
 
 import * as React from "react";
-import { PMMLParams } from "../api";
 import { useContext } from "react";
+import { DataTypeProps, PMMLParams } from "../api";
 
 export interface BoxedExpressionGlobalContextProps {
   decisionNodeId: string;
   pmmlParams?: PMMLParams;
+  dataTypes: DataTypeProps[];
   supervisorHash: string;
   setSupervisorHash: (hash: string) => void;
   editorRef: React.RefObject<HTMLDivElement>;
   currentlyOpenedHandlerCallback: React.Dispatch<React.SetStateAction<boolean>>;
   setCurrentlyOpenedHandlerCallback: React.Dispatch<
     React.SetStateAction<React.Dispatch<React.SetStateAction<boolean>>>
-  >;
+    >;
 }
 
 export const BoxedExpressionGlobalContext = React.createContext<BoxedExpressionGlobalContextProps>(

--- a/kogito-editors-js/packages/boxed-expression-component/src/i18n/BoxedExpressionEditorI18n.ts
+++ b/kogito-editors-js/packages/boxed-expression-component/src/i18n/BoxedExpressionEditorI18n.ts
@@ -32,6 +32,10 @@ interface BoxedExpressionEditorDictionary extends ReferenceDictionary {
   context: string;
   contextEntry: string;
   dataType: string;
+  dataTypeDropDown: {
+    default: string;
+    custom: string;
+  };
   decisionRule: string;
   decisionTable: string;
   document: string;

--- a/kogito-editors-js/packages/boxed-expression-component/src/i18n/locales/en.ts
+++ b/kogito-editors-js/packages/boxed-expression-component/src/i18n/locales/en.ts
@@ -33,6 +33,10 @@ export const en: BoxedExpressionEditorI18n = {
   context: "Context",
   contextEntry: "CONTEXT ENTRY",
   dataType: "Data Type",
+  dataTypeDropDown: {
+    default: "DEFAULT",
+    custom: "CUSTOM",
+  },
   decisionRule: "DECISION RULE",
   decisionTable: "Decision Table",
   delete: "Delete",

--- a/kogito-editors-js/packages/dmn-loader/src/index.tsx
+++ b/kogito-editors-js/packages/dmn-loader/src/index.tsx
@@ -40,7 +40,7 @@ setupWire();
 const BoxedExpressionWrapper: React.FunctionComponent<BoxedExpressionEditorProps> = ({
   decisionNodeId,
   expressionDefinition,
-  dataTypeProps,
+  dataTypes,
   clearSupportedOnRootExpression,
   pmmlParams,
 }: BoxedExpressionEditorProps) => {
@@ -97,7 +97,7 @@ const BoxedExpressionWrapper: React.FunctionComponent<BoxedExpressionEditorProps
     <BoxedExpressionEditor
       decisionNodeId={decisionNodeId}
       expressionDefinition={updatedDefinition}
-      dataTypeProps={dataTypeProps}
+      dataTypes={dataTypes}
       clearSupportedOnRootExpression={clearSupportedOnRootExpression}
       pmmlParams={pmmlParams}
     />
@@ -108,7 +108,7 @@ const renderBoxedExpressionEditor = (
   selector: string,
   decisionNodeId: string,
   expressionDefinition: ExpressionProps,
-  dataTypeProps: DataTypeProps[],
+  dataTypes: DataTypeProps[],
   clearSupportedOnRootExpression: boolean,
   pmmlParams: PMMLParams
 ) => {
@@ -116,7 +116,7 @@ const renderBoxedExpressionEditor = (
     <BoxedExpressionWrapper
       decisionNodeId={decisionNodeId}
       expressionDefinition={expressionDefinition}
-      dataTypeProps={dataTypeProps}
+      dataTypes={dataTypes}
       clearSupportedOnRootExpression={clearSupportedOnRootExpression}
       pmmlParams={pmmlParams}
     />,

--- a/kogito-editors-js/packages/dmn-loader/src/index.tsx
+++ b/kogito-editors-js/packages/dmn-loader/src/index.tsx
@@ -19,6 +19,7 @@ import {
   BoxedExpressionEditor,
   BoxedExpressionEditorProps,
   ContextProps,
+  DataTypeProps,
   DecisionTableProps,
   ExpressionProps,
   FunctionProps,
@@ -39,6 +40,7 @@ setupWire();
 const BoxedExpressionWrapper: React.FunctionComponent<BoxedExpressionEditorProps> = ({
   decisionNodeId,
   expressionDefinition,
+  dataTypeProps,
   clearSupportedOnRootExpression,
   pmmlParams,
 }: BoxedExpressionEditorProps) => {
@@ -95,6 +97,7 @@ const BoxedExpressionWrapper: React.FunctionComponent<BoxedExpressionEditorProps
     <BoxedExpressionEditor
       decisionNodeId={decisionNodeId}
       expressionDefinition={updatedDefinition}
+      dataTypeProps={dataTypeProps}
       clearSupportedOnRootExpression={clearSupportedOnRootExpression}
       pmmlParams={pmmlParams}
     />
@@ -105,6 +108,7 @@ const renderBoxedExpressionEditor = (
   selector: string,
   decisionNodeId: string,
   expressionDefinition: ExpressionProps,
+  dataTypeProps: DataTypeProps[],
   clearSupportedOnRootExpression: boolean,
   pmmlParams: PMMLParams
 ) => {
@@ -112,6 +116,7 @@ const renderBoxedExpressionEditor = (
     <BoxedExpressionWrapper
       decisionNodeId={decisionNodeId}
       expressionDefinition={expressionDefinition}
+      dataTypeProps={dataTypeProps}
       clearSupportedOnRootExpression={clearSupportedOnRootExpression}
       pmmlParams={pmmlParams}
     />,


### PR DESCRIPTION
Data types should come from the DMN editor. So the React component will take a series of default + custom data types as input.