### PR TITLE
KOGITO-6449: [DMN Designer] Regression for setting name/dataType for BKM nodes, after KOGITO-4195

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/SaveCurrentStateCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/SaveCurrentStateCommand.java
@@ -17,10 +17,13 @@
 package org.kie.workbench.common.dmn.client.editors.expressions;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.enterprise.event.Event;
 
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.client.editors.expressions.commands.UpdateCanvasNodeNameCommand;
 import org.kie.workbench.common.dmn.client.editors.expressions.util.ExpressionState;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
@@ -34,6 +37,8 @@ public class SaveCurrentStateCommand extends AbstractCanvasCommand {
     private final Event<ExpressionEditorChanged> editorSelectedEvent;
     private final ExpressionEditorView view;
     private final String nodeUUID;
+    private final Optional<HasName> hasName;
+    private final UpdateCanvasNodeNameCommand updateCanvasNodeCommand;
 
     private ExpressionState originalState;
     private ExpressionState stateBeforeUndo;
@@ -41,16 +46,30 @@ public class SaveCurrentStateCommand extends AbstractCanvasCommand {
     public SaveCurrentStateCommand(final HasExpression hasExpression,
                                    final Event<ExpressionEditorChanged> editorSelectedEvent,
                                    final ExpressionEditorView view,
-                                   final String nodeUUID) {
+                                   final String nodeUUID,
+                                   final Optional<HasName> hasName,
+                                   final UpdateCanvasNodeNameCommand updateCanvasNodeNameCommand) {
         this.hasExpression = hasExpression;
         this.editorSelectedEvent = editorSelectedEvent;
         this.view = view;
         this.nodeUUID = nodeUUID;
+        this.hasName = hasName;
+        this.updateCanvasNodeCommand = updateCanvasNodeNameCommand;
         this.originalState = new ExpressionState(hasExpression,
                                                  editorSelectedEvent,
                                                  view,
-                                                 nodeUUID);
+                                                 nodeUUID,
+                                                 hasName,
+                                                 updateCanvasNodeCommand);
         originalState.saveCurrentState();
+    }
+
+    public UpdateCanvasNodeNameCommand getUpdateCanvasNodeCommand() {
+        return updateCanvasNodeCommand;
+    }
+
+    public Optional<HasName> getHasName() {
+        return hasName;
     }
 
     public HasExpression getHasExpression() {
@@ -99,7 +118,9 @@ public class SaveCurrentStateCommand extends AbstractCanvasCommand {
             final ExpressionState newStateBeforeUndo = new ExpressionState(getHasExpression(),
                                                                            getEditorSelectedEvent(),
                                                                            getView(),
-                                                                           getNodeUUID());
+                                                                           getNodeUUID(),
+                                                                           getHasName(),
+                                                                           getUpdateCanvasNodeCommand());
             newStateBeforeUndo.saveCurrentState();
             setStateBeforeUndo(newStateBeforeUndo);
         }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/ClearExpressionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/ClearExpressionCommand.java
@@ -16,9 +16,12 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
+import java.util.Optional;
+
 import javax.enterprise.event.Event;
 
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.ExpressionProps;
@@ -30,8 +33,9 @@ public class ClearExpressionCommand extends FillExpressionCommand<ExpressionProp
                                   final ExpressionProps expressionProps,
                                   final Event<ExpressionEditorChanged> editorSelectedEvent,
                                   final String nodeUUID,
-                                  final ExpressionEditorView view) {
-        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+                                  final ExpressionEditorView view,
+                                  final Optional<HasName> hasName) {
+        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, hasName);
     }
 
     @Override
@@ -48,5 +52,4 @@ public class ClearExpressionCommand extends FillExpressionCommand<ExpressionProp
     protected Expression getNewExpression() {
         return null;
     }
-
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillContextExpressionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillContextExpressionCommand.java
@@ -16,9 +16,12 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
+import java.util.Optional;
+
 import javax.enterprise.event.Event;
 
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.model.Context;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
@@ -33,8 +36,9 @@ public class FillContextExpressionCommand extends FillExpressionCommand<ContextP
                                         final ContextProps expressionProps,
                                         final Event<ExpressionEditorChanged> editorSelectedEvent,
                                         final String nodeUUID,
-                                        final ExpressionEditorView view) {
-        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+                                        final ExpressionEditorView view,
+                                        final Optional<HasName> hasName) {
+        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, hasName);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillDecisionTableExpressionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillDecisionTableExpressionCommand.java
@@ -16,9 +16,12 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
+import java.util.Optional;
+
 import javax.enterprise.event.Event;
 
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.model.DecisionTable;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
@@ -33,8 +36,9 @@ public class FillDecisionTableExpressionCommand extends FillExpressionCommand<De
                                               final DecisionTableProps expressionProps,
                                               final Event<ExpressionEditorChanged> editorSelectedEvent,
                                               final String nodeUUID,
-                                              final ExpressionEditorView view) {
-        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+                                              final ExpressionEditorView view,
+                                              final Optional<HasName> hasName) {
+        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, hasName);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillFunctionExpressionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillFunctionExpressionCommand.java
@@ -16,9 +16,12 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
+import java.util.Optional;
+
 import javax.enterprise.event.Event;
 
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.FunctionDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
@@ -33,8 +36,9 @@ public class FillFunctionExpressionCommand extends FillExpressionCommand<Functio
                                          final FunctionProps expressionProps,
                                          final Event<ExpressionEditorChanged> editorSelectedEvent,
                                          final String nodeUUID,
-                                         final ExpressionEditorView view) {
-        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+                                         final ExpressionEditorView view,
+                                         final Optional<HasName> hasName) {
+        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, hasName);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillInvocationExpressionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillInvocationExpressionCommand.java
@@ -16,9 +16,12 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
+import java.util.Optional;
+
 import javax.enterprise.event.Event;
 
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.Invocation;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
@@ -33,8 +36,9 @@ public class FillInvocationExpressionCommand extends FillExpressionCommand<Invoc
                                            final InvocationProps expressionProps,
                                            final Event<ExpressionEditorChanged> editorSelectedEvent,
                                            final String nodeUUID,
-                                           final ExpressionEditorView view) {
-        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+                                           final ExpressionEditorView view,
+                                           final Optional<HasName> hasName) {
+        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, hasName);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillListExpressionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillListExpressionCommand.java
@@ -16,9 +16,12 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
+import java.util.Optional;
+
 import javax.enterprise.event.Event;
 
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.List;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
@@ -33,8 +36,9 @@ public class FillListExpressionCommand extends FillExpressionCommand<ListProps> 
                                      final ListProps expressionProps,
                                      final Event<ExpressionEditorChanged> editorSelectedEvent,
                                      final String nodeUUID,
-                                     final ExpressionEditorView view) {
-        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+                                     final ExpressionEditorView view,
+                                     final Optional<HasName> hasName) {
+        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, hasName);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillLiteralExpressionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillLiteralExpressionCommand.java
@@ -16,9 +16,12 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
+import java.util.Optional;
+
 import javax.enterprise.event.Event;
 
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.LiteralExpression;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
@@ -33,8 +36,9 @@ public class FillLiteralExpressionCommand extends FillExpressionCommand<LiteralP
                                         final LiteralProps expressionProps,
                                         final Event<ExpressionEditorChanged> editorSelectedEvent,
                                         final String nodeUUID,
-                                        final ExpressionEditorView view) {
-        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+                                        final ExpressionEditorView view,
+                                        final Optional<HasName> hasName) {
+        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, hasName);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillRelationExpressionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillRelationExpressionCommand.java
@@ -16,9 +16,12 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
+import java.util.Optional;
+
 import javax.enterprise.event.Event;
 
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.Relation;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
@@ -33,8 +36,9 @@ public class FillRelationExpressionCommand extends FillExpressionCommand<Relatio
                                          final RelationProps expressionProps,
                                          final Event<ExpressionEditorChanged> editorSelectedEvent,
                                          final String nodeUUID,
-                                         final ExpressionEditorView view) {
-        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+                                         final ExpressionEditorView view,
+                                         final Optional<HasName> hasName) {
+        super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, hasName);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/UpdateCanvasNodeNameCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/UpdateCanvasNodeNameCommand.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.expressions.commands;
+
+import java.util.Optional;
+
+import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+
+public class UpdateCanvasNodeNameCommand {
+
+    private final SessionManager sessionManager;
+    private final DefinitionUtils definitionUtils;
+    private final DefaultCanvasCommandFactory canvasCommandFactory;
+
+    public UpdateCanvasNodeNameCommand(final SessionManager sessionManager,
+                                       final DefinitionUtils definitionUtils,
+                                       final DefaultCanvasCommandFactory canvasCommandFactory) {
+        this.sessionManager = sessionManager;
+        this.definitionUtils = definitionUtils;
+        this.canvasCommandFactory = canvasCommandFactory;
+    }
+
+    public void execute(final String nodeUUID,
+                        final Optional<HasName> hasName) {
+
+        final AbstractCanvasHandler canvasHandler = (AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler();
+        final Element element = canvasHandler.getGraphIndex().get(nodeUUID);
+
+        if (element.getContent() instanceof Definition) {
+            final Definition definition = (Definition) element.getContent();
+            final String nameId = definitionUtils.getNameIdentifier(definition.getDefinition());
+
+            final CanvasCommand<AbstractCanvasHandler> command = getCommand(hasName, element, nameId);
+
+            command.execute(canvasHandler);
+        }
+    }
+
+    CanvasCommand<AbstractCanvasHandler> getCommand(final Optional<HasName> hasName,
+                                                    final Element element,
+                                                    final String nameId) {
+        return canvasCommandFactory.updatePropertyValue(element,
+                                                        nameId,
+                                                        hasName.orElse(HasName.NOP).getValue());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/util/ExpressionState.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/util/ExpressionState.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.editors.expressions.util;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.enterprise.event.Event;
 
@@ -28,6 +29,7 @@ import org.kie.workbench.common.dmn.api.definition.model.InformationItemPrimary;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
+import org.kie.workbench.common.dmn.client.editors.expressions.commands.UpdateCanvasNodeNameCommand;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 
 public class ExpressionState {
@@ -36,6 +38,8 @@ public class ExpressionState {
     private final Event<ExpressionEditorChanged> editorSelectedEvent;
     private final ExpressionEditorView view;
     private final String nodeUUID;
+    private final Optional<HasName> hasName;
+    private final UpdateCanvasNodeNameCommand updateCanvasNodeCommand;
     private Expression savedExpression;
     private String savedExpressionName;
     private QName savedTypeRef;
@@ -43,11 +47,19 @@ public class ExpressionState {
     public ExpressionState(final HasExpression hasExpression,
                            final Event<ExpressionEditorChanged> editorSelectedEvent,
                            final ExpressionEditorView view,
-                           final String nodeUUID) {
+                           final String nodeUUID,
+                           final Optional<HasName> hasName,
+                           final UpdateCanvasNodeNameCommand updateCanvasNodeNameCommand) {
         this.hasExpression = hasExpression;
         this.editorSelectedEvent = editorSelectedEvent;
         this.view = view;
         this.nodeUUID = nodeUUID;
+        this.hasName = hasName;
+        this.updateCanvasNodeCommand = updateCanvasNodeNameCommand;
+    }
+
+    public Optional<HasName> getHasName() {
+        return hasName;
     }
 
     public ExpressionEditorView getView() {
@@ -107,7 +119,13 @@ public class ExpressionState {
     }
 
     void setExpressionName(final String expressionName) {
-        HasExpressionUtils.setExpressionName(getHasExpression(), expressionName);
+        final HasName fallbackHasName = getFallbackHasName();
+        HasNameUtils.setName(getHasName().orElse(fallbackHasName), expressionName);
+        updateCanvasNodeCommand.execute(getNodeUUID(), getHasName());
+    }
+
+    HasName getFallbackHasName() {
+        return getHasExpression() instanceof HasName ? (HasName) getHasExpression() : HasName.NOP;
     }
 
     void restoreExpression() {
@@ -128,10 +146,8 @@ public class ExpressionState {
     }
 
     void saveCurrentExpressionName() {
-        if (getHasExpression() instanceof HasName) {
-            final HasName hasName = (HasName) getHasExpression();
-            setSavedExpressionName(hasName.getName().getValue());
-        }
+        final HasName fallbackHasName = getFallbackHasName();
+        setSavedExpressionName(getHasName().orElse(fallbackHasName).getName().getValue());
     }
 
     QName getCurrentTypeRef() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/util/HasNameUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/util/HasNameUtils.java
@@ -18,29 +18,24 @@ package org.kie.workbench.common.dmn.client.editors.expressions.util;
 
 import java.util.Objects;
 
-import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 
-public class HasExpressionUtils {
+public class HasNameUtils {
 
-    private HasExpressionUtils() {
+    private HasNameUtils() {
         // Private constructor for utility class with only static members
     }
 
-    public static void setExpressionName(final HasExpression hasExpression,
-                                         final String expressionName) {
-
-        if (hasExpression instanceof HasName) {
-            final HasName hasName = (HasName) hasExpression;
-            final Name name;
-            if (Objects.isNull(hasName.getName())) {
-                name = new Name();
-                hasName.setName(name);
-            } else {
-                name = hasName.getName();
-            }
-            name.setValue(expressionName);
+    public static void setName(final HasName hasName,
+                               final String expressionName) {
+        final Name name;
+        if (Objects.isNull(hasName.getName())) {
+            name = new Name();
+            hasName.setName(name);
+        } else {
+            name = hasName.getName();
         }
+        name.setValue(expressionName);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -74,11 +74,8 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanelContainer;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
-import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
-import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
@@ -687,15 +684,13 @@ public class ExpressionEditorViewImplTest {
 
         final CompositeCommand.Builder commandBuilder = mock(CompositeCommand.Builder.class);
         doReturn(commandBuilder).when(view).createCommandBuilder();
-
         doNothing().when(view).addExpressionCommand(any(), eq(commandBuilder));
-        doNothing().when(view).addUpdatePropertyNameCommand(commandBuilder);
         doNothing().when(view).execute(commandBuilder);
+        doReturn(Optional.empty()).when(view).getHasName();
 
         view.notifyUserAction();
 
         verify(view).addExpressionCommand(captor.capture(), eq(commandBuilder));
-        verify(view).addUpdatePropertyNameCommand(commandBuilder);
         verify(view).execute(commandBuilder);
 
         final SaveCurrentStateCommand command = captor.getValue();
@@ -704,35 +699,6 @@ public class ExpressionEditorViewImplTest {
         assertEquals(editorSelectedEvent, command.getEditorSelectedEvent());
         assertEquals(view, command.getView());
         assertEquals(NODE_UUID, command.getNodeUUID());
-    }
-
-    @Test
-    public void testAddUpdatePropertyNameCommand() {
-
-        final CompositeCommand.Builder commandBuilder = mock(CompositeCommand.Builder.class);
-        final Index graphIndex = mock(Index.class);
-        final org.kie.workbench.common.stunner.core.graph.Element element = mock(org.kie.workbench.common.stunner.core.graph.Element.class);
-        final Definition definition = mock(Definition.class);
-        final Object theDefinition = mock(Object.class);
-        final HasName hasName = mock(HasName.class);
-        final Optional<HasName> optionalHasName = Optional.of(hasName);
-        final Name name = mock(Name.class);
-        final String nameId = "nameId";
-        final CanvasCommand<AbstractCanvasHandler> updateCommand = mock(CanvasCommand.class);
-
-        doReturn(optionalHasName).when(view).getHasName();
-
-        when(hasName.getValue()).thenReturn(name);
-        when(definition.getDefinition()).thenReturn(theDefinition);
-        when(canvasCommandFactory.updatePropertyValue(element, nameId, name)).thenReturn(updateCommand);
-        when(definitionUtils.getNameIdentifier(theDefinition)).thenReturn(nameId);
-        when(element.getContent()).thenReturn(definition);
-        when(graphIndex.get(NODE_UUID)).thenReturn(element);
-        when(canvasHandler.getGraphIndex()).thenReturn(graphIndex);
-
-        view.addUpdatePropertyNameCommand(commandBuilder);
-
-        verify(commandBuilder).addCommand(updateCommand);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/SaveCurrentStateCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/SaveCurrentStateCommandTest.java
@@ -16,11 +16,15 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions;
 
+import java.util.Optional;
+
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.client.editors.expressions.commands.UpdateCanvasNodeNameCommand;
 import org.kie.workbench.common.dmn.client.editors.expressions.util.ExpressionState;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
@@ -53,12 +57,19 @@ public class SaveCurrentStateCommandTest {
     @Mock
     private ExpressionEditorView view;
 
+    @Mock
+    private UpdateCanvasNodeNameCommand updateCanvasNodeNameCommand;
+
+    private Optional<HasName> hasName = Optional.empty();
+
     @Before
     public void setup() {
         command = spy(new SaveCurrentStateCommand(hasExpression,
                                                   editorSelectedEvent,
                                                   view,
-                                                  NODE_UUID));
+                                                  NODE_UUID,
+                                                  hasName,
+                                                  updateCanvasNodeNameCommand));
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/ClearExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/ClearExpressionCommandTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.enterprise.event.Event;
 
@@ -25,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.ExpressionProps;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
@@ -48,6 +50,8 @@ public class ClearExpressionCommandTest {
     @Mock
     private ExpressionEditorView view;
 
+    private Optional<HasName> hasName = Optional.empty();
+
     private ClearExpressionCommand expressionCommand;
 
     private final String nodeUUID = "node uuid";
@@ -58,7 +62,8 @@ public class ClearExpressionCommandTest {
                                                             expressionProps,
                                                             editorSelectedEvent,
                                                             nodeUUID,
-                                                            view);
+                                                            view,
+                                                            hasName);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillContextExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillContextExpressionCommandTest.java
@@ -16,11 +16,14 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
+import java.util.Optional;
+
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.model.Context;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
@@ -56,6 +59,8 @@ public class FillContextExpressionCommandTest {
     @Mock
     private Context existingExpression;
 
+    private Optional<HasName> hasName = Optional.empty();
+
     @Before
     public void setup() {
 
@@ -65,7 +70,8 @@ public class FillContextExpressionCommandTest {
                                                        expressionProps,
                                                        editorSelectedEvent,
                                                        "nodeUUID",
-                                                       view));
+                                                       view,
+                                                       hasName));
         doNothing().when(command).fill(any(), any());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillDecisionTableExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillDecisionTableExpressionCommandTest.java
@@ -16,11 +16,14 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
+import java.util.Optional;
+
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.model.DecisionTable;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
@@ -56,6 +59,8 @@ public class FillDecisionTableExpressionCommandTest {
     @Mock
     private DecisionTable existingExpression;
 
+    private Optional<HasName> hasName = Optional.empty();
+
     @Before
     public void setup() {
 
@@ -65,7 +70,8 @@ public class FillDecisionTableExpressionCommandTest {
                                                              expressionProps,
                                                              editorSelectedEvent,
                                                              "nodeUUID",
-                                                             view));
+                                                             view,
+                                                             hasName));
         doNothing().when(command).fill(any(), any());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillExpressionCommandTest.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
+import java.util.Optional;
+
 import javax.enterprise.event.Event;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -67,6 +69,8 @@ public class FillExpressionCommandTest {
     @Mock
     private Expression existingExpression;
 
+    private Optional<HasName> hasName = Optional.empty();
+
     private final String nodeUUID = "uuid";
 
     private final String name = "name";
@@ -90,7 +94,8 @@ public class FillExpressionCommandTest {
                                                     expressionProps,
                                                     editorSelectedEvent,
                                                     nodeUUID,
-                                                    view));
+                                                    view,
+                                                    hasName));
     }
 
     @Test
@@ -182,8 +187,9 @@ public class FillExpressionCommandTest {
                                          final ExpressionProps expressionProps,
                                          final Event<ExpressionEditorChanged> editorSelectedEvent,
                                          final String nodeUUID,
-                                         final ExpressionEditorView view) {
-            super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view);
+                                         final ExpressionEditorView view,
+                                         final Optional<HasName> hasName) {
+            super(hasExpression, expressionProps, editorSelectedEvent, nodeUUID, view, hasName);
         }
 
         @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillFunctionExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillFunctionExpressionCommandTest.java
@@ -16,11 +16,14 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
+import java.util.Optional;
+
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.FunctionDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
@@ -56,6 +59,8 @@ public class FillFunctionExpressionCommandTest {
     @Mock
     private FunctionDefinition existingExpression;
 
+    private Optional<HasName> hasName = Optional.empty();
+
     @Before
     public void setup() {
 
@@ -65,7 +70,8 @@ public class FillFunctionExpressionCommandTest {
                                                         expressionProps,
                                                         editorSelectedEvent,
                                                         "nodeUUID",
-                                                        view));
+                                                        view,
+                                                        hasName));
         doNothing().when(command).fill(any(), any());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillInvocationExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillInvocationExpressionCommandTest.java
@@ -16,11 +16,14 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
+import java.util.Optional;
+
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.Invocation;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
@@ -56,6 +59,8 @@ public class FillInvocationExpressionCommandTest {
     @Mock
     private Invocation existingExpression;
 
+    private Optional<HasName> hasName = Optional.empty();
+
     @Before
     public void setup() {
 
@@ -65,7 +70,8 @@ public class FillInvocationExpressionCommandTest {
                                                           expressionProps,
                                                           editorSelectedEvent,
                                                           "nodeUUID",
-                                                          view));
+                                                          view,
+                                                          hasName));
         doNothing().when(command).fill(any(), any());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillListExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillListExpressionCommandTest.java
@@ -16,12 +16,15 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
+import java.util.Optional;
+
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import junit.framework.TestCase;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.List;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
@@ -56,6 +59,8 @@ public class FillListExpressionCommandTest extends TestCase {
     @Mock
     private List existingExpression;
 
+    private Optional<HasName> hasName = Optional.empty();
+
     @Before
     public void setup() {
 
@@ -65,7 +70,8 @@ public class FillListExpressionCommandTest extends TestCase {
                                                     expressionProps,
                                                     editorSelectedEvent,
                                                     "nodeUUID",
-                                                    view));
+                                                    view,
+                                                    hasName));
         doNothing().when(command).fill(any(), any());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillLiteralExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillLiteralExpressionCommandTest.java
@@ -16,11 +16,14 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
+import java.util.Optional;
+
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.LiteralExpression;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
@@ -56,6 +59,8 @@ public class FillLiteralExpressionCommandTest {
     @Mock
     private LiteralExpression existingExpression;
 
+    private Optional<HasName> hasName = Optional.empty();
+
     @Before
     public void setup() {
 
@@ -65,7 +70,8 @@ public class FillLiteralExpressionCommandTest {
                                                        expressionProps,
                                                        editorSelectedEvent,
                                                        "nodeUUID",
-                                                       view));
+                                                       view,
+                                                       hasName));
         doNothing().when(command).fill(any(), any());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillRelationExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/FillRelationExpressionCommandTest.java
@@ -16,11 +16,14 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.commands;
 
+import java.util.Optional;
+
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.Relation;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
@@ -56,6 +59,8 @@ public class FillRelationExpressionCommandTest {
     @Mock
     private Relation existingExpression;
 
+    private Optional<HasName> hasName = Optional.empty();
+
     private final String nodeUUID = "nodeUUID";
 
     @Before
@@ -67,7 +72,8 @@ public class FillRelationExpressionCommandTest {
                                                         expressionProps,
                                                         editorSelectedEvent,
                                                         nodeUUID,
-                                                        view));
+                                                        view,
+                                                        hasName));
         doNothing().when(command).fill(any(), any());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/UpdateCanvasNodeNameCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/commands/UpdateCanvasNodeNameCommandTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.expressions.commands;
+
+import java.util.Optional;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class UpdateCanvasNodeNameCommandTest {
+
+    @Mock
+    private SessionManager sessionManager;
+
+    @Mock
+    private DefinitionUtils definitionUtils;
+
+    @Mock
+    private DefaultCanvasCommandFactory canvasCommandFactory;
+
+    @Mock
+    private AbstractCanvasHandler canvasHandler;
+
+    @Mock
+    private Index graphIndex;
+
+    private UpdateCanvasNodeNameCommand command;
+
+    @Before
+    public void setup() {
+
+        final ClientSession currentSession = mock(ClientSession.class);
+
+        when(canvasHandler.getGraphIndex()).thenReturn(graphIndex);
+        when(currentSession.getCanvasHandler()).thenReturn(canvasHandler);
+        when(sessionManager.getCurrentSession()).thenReturn(currentSession);
+
+        this.command = spy(new UpdateCanvasNodeNameCommand(sessionManager,
+                                                           definitionUtils,
+                                                           canvasCommandFactory));
+    }
+
+    @Test
+    public void testExecute() {
+
+        final String nodeUUID = "node uuid";
+        final Optional<HasName> hasName = Optional.of(mock(HasName.class));
+
+        final Element element = mock(Element.class);
+        final Definition definition = mock(Definition.class);
+        final Object definitionObject = mock(Object.class);
+        final String nameId = "nameId";
+
+        final CanvasCommand canvasCommand = mock(CanvasCommand.class);
+
+        doReturn(canvasCommand).when(command).getCommand(hasName,
+                                                         element,
+                                                         nameId);
+
+        when(definitionUtils.getNameIdentifier(definitionObject)).thenReturn(nameId);
+        when(definition.getDefinition()).thenReturn(definitionObject);
+        when(element.getContent()).thenReturn(definition);
+        when(graphIndex.get(nodeUUID)).thenReturn(element);
+
+        command.execute(nodeUUID, hasName);
+
+        verify(canvasCommand).execute(canvasHandler);
+    }
+
+    @Test
+    public void testGetCommand_WhenHasNameHasValue() {
+
+        final Element element = mock(Element.class);
+        final String nameId = "nameId";
+        final HasName hasName = mock(HasName.class);
+        final Name name = mock(Name.class);
+        final CanvasCommand<AbstractCanvasHandler> canvasCommand = mock(CanvasCommand.class);
+
+        when(hasName.getValue()).thenReturn(name);
+        when(canvasCommandFactory.updatePropertyValue(element, nameId, name)).thenReturn(canvasCommand);
+
+        final CanvasCommand<AbstractCanvasHandler> actualCommand = command.getCommand(Optional.of(hasName),
+                                                                                      element,
+                                                                                      nameId);
+
+        assertEquals(canvasCommand, actualCommand);
+    }
+
+    @Test
+    public void testGetCommand_WhenHasNameDoesNotHasValue() {
+
+        final Element element = mock(Element.class);
+        final String nameId = "nameId";
+        final Name name = mock(Name.class);
+        final CanvasCommand<AbstractCanvasHandler> canvasCommand = mock(CanvasCommand.class);
+
+        when(canvasCommandFactory.updatePropertyValue(element, nameId, HasName.NOP.getValue())).thenReturn(canvasCommand);
+
+        final CanvasCommand<AbstractCanvasHandler> actualCommand = command.getCommand(Optional.empty(),
+                                                                                      element,
+                                                                                      nameId);
+
+        assertEquals(canvasCommand, actualCommand);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/util/ExpressionStateTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/util/ExpressionStateTest.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.util;
 
+import java.util.Optional;
+
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +31,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
+import org.kie.workbench.common.dmn.client.editors.expressions.commands.UpdateCanvasNodeNameCommand;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
@@ -56,16 +59,24 @@ public class ExpressionStateTest {
     @Mock
     private ExpressionEditorView view;
 
+    @Mock
+    private UpdateCanvasNodeNameCommand updateCanvasNodeCommand;
+
+    private Optional<HasName> hasName = Optional.empty();
+
     private static final String NODE_UUID = "uuid";
 
     private ExpressionState expressionState;
 
     @Before
     public void setup() {
+
         expressionState = spy(new ExpressionState(hasExpression,
                                                   editorSelectedEvent,
                                                   view,
-                                                  NODE_UUID));
+                                                  NODE_UUID,
+                                                  hasName,
+                                                  updateCanvasNodeCommand));
     }
 
     @Test
@@ -239,5 +250,35 @@ public class ExpressionStateTest {
         final Expression saved = expressionState.getSavedExpression();
 
         assertEquals(expressionCopy, saved);
+    }
+
+    @Test
+    public void testSetExpressionName() {
+
+        final String expressionName = "expression name";
+
+        expressionState.setExpressionName(expressionName);
+
+        verify(updateCanvasNodeCommand).execute(NODE_UUID,
+                                                hasName);
+    }
+
+    @Test
+    public void testGetFallbackHasName_WhenHasExpressionIsNotHasName() {
+
+        final HasExpression hasExpressionNotHasName = mock(HasExpression.class);
+        doReturn(hasExpressionNotHasName).when(expressionState).getHasExpression();
+
+        final HasName hasNameFallback = expressionState.getFallbackHasName();
+
+        assertEquals(HasName.NOP, hasNameFallback);
+    }
+
+    @Test
+    public void testGetFallbackHasName_WhenHasExpressionIsHasName() {
+
+        final HasName hasNameFallback = expressionState.getFallbackHasName();
+
+        assertEquals(hasExpression, hasNameFallback);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/util/HasNameUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/util/HasNameUtilsTest.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.dmn.client.editors.expressions.util;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.mockito.ArgumentCaptor;
@@ -31,32 +30,32 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
-public class HasExpressionUtilsTest {
+public class HasNameUtilsTest {
 
-    @Mock(extraInterfaces = HasName.class)
-    private HasExpression hasExpression;
+    @Mock
+    private HasName hasName;
 
     private final static String EXPRESSION_NAME = "expression name";
 
     @Test
-    public void testSetExpressionName_WhenHaveName() {
+    public void testSetName_WhenHaveNameObject() {
 
         final Name name = mock(Name.class);
 
-        when(((HasName) hasExpression).getName()).thenReturn(name);
+        when(hasName.getName()).thenReturn(name);
 
-        HasExpressionUtils.setExpressionName(hasExpression, EXPRESSION_NAME);
+        HasNameUtils.setName(hasName, EXPRESSION_NAME);
 
         verify(name).setValue(EXPRESSION_NAME);
     }
 
     @Test
-    public void testSetExpressionName_WhenNameIsNull() {
+    public void testSetName_WhenNameObjectIsNull() {
 
         final ArgumentCaptor<Name> nameCaptor = ArgumentCaptor.forClass(Name.class);
-        HasExpressionUtils.setExpressionName(hasExpression, EXPRESSION_NAME);
+        HasNameUtils.setName(hasName, EXPRESSION_NAME);
 
-        verify((HasName) hasExpression).setName(nameCaptor.capture());
+        verify(hasName).setName(nameCaptor.capture());
 
         final Name currentName = nameCaptor.getValue();
 


### PR DESCRIPTION
I found out another issue during the development of this ticket, but it requires more time so I decided to create another ticket:
[Undo/Redo does not work for BKM nodes.](https://issues.redhat.com/browse/KOGITO-6474).